### PR TITLE
release: 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-05
+
 ### Added
 - `ProviderNotInstalledError` (a subclass of `ExtractionError`) raised with an
   actionable `pip install openextract[...]` hint when a model is requested whose
@@ -12,6 +14,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `--continue-on-error` flag on the `openextract` CLI: in batch mode, keep
   processing remaining inputs when one fails, emit per-item errors inline, and
   exit `7` if any input failed (default remains abort-on-first-failure).
+- Reorganized `examples/` into dedicated use-case folders (`basic/`, `images/`,
+  `documents/`, `audio/`, `batch/`, `async/`, `advanced/`, `cli/`) with shared
+  bootstrap helpers, bundled fixtures, and a `run_all.py` runner.
+- xAI gRPC error classification: `grpc.aio.AioRpcError` from xAI model calls is
+  now caught and re-raised as `ModelError` (consistent with other providers).
+- Updated all examples and docs to use the `xai:` model string prefix (e.g.
+  `xai:grok-4.3`) matching pydantic-ai conventions.
 
 ## [0.8.0] - 2026-06-02
 
@@ -111,7 +120,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.5.0...v0.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.8.0"
+version = "0.9.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

- Bumps `version` in `pyproject.toml` from `0.8.0` → `0.9.0`
- Promotes the `[Unreleased]` CHANGELOG entries to `[0.9.0] - 2026-06-05` and adds a fresh empty `[Unreleased]` block
- Updates the diff-comparison links at the bottom of `CHANGELOG.md`

## What's in this release

### Added
- **`ProviderNotInstalledError`** — a subclass of `ExtractionError` raised with an actionable `pip install openextract[...]` hint when a model is requested whose provider extra is not installed; CLI exits with code `6`.
- **`--continue-on-error`** CLI flag — in batch mode, keep processing remaining inputs when one fails, emit per-item errors inline, and exit `7` if any input failed (default still aborts on first failure).
- **Examples reorganization** — `examples/` split into dedicated use-case folders (`basic/`, `images/`, `documents/`, `audio/`, `batch/`, `async/`, `advanced/`, `cli/`) with shared bootstrap helpers, bundled fixtures, and a `run_all.py` runner.
- **xAI gRPC error classification** — `grpc.aio.AioRpcError` from xAI model calls is caught and re-raised as `ModelError`, consistent with other providers.
- **xAI model string updates** — all examples and docs updated to use the `xai:` prefix (e.g. `xai:grok-4.3`) matching pydantic-ai conventions.

## Test plan
- [ ] CI passes (tests, ruff, ty)
- [ ] `pyproject.toml` version reads `0.9.0`
- [ ] CHANGELOG `[0.9.0]` section is dated `2026-06-05` and diff links point to the correct tags

https://claude.ai/code/session_0161sUT8Ry8tiPwJcPdtuznD

---
_Generated by [Claude Code](https://claude.ai/code/session_0161sUT8Ry8tiPwJcPdtuznD)_