### PR TITLE
Release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-21
+
 ### Added
 - `ProviderNotInstalledError` (a subclass of `ExtractionError`) raised with an
   actionable `pip install openextract[...]` hint when a model is requested whose
@@ -111,7 +113,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.5.0...v0.6.0

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,9 +93,9 @@
           <!-- Badge -->
           <a href="#whats-new" class="animate-slide-up opacity-0 inline-flex items-center gap-2.5 px-3 py-1.5 border border-black/10 bg-white text-xs mb-8 hover:border-black/30 transition-colors">
             <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-            <span class="font-mono text-black/40">v0.8.0</span>
+            <span class="font-mono text-black/40">v0.9.0</span>
             <span class="text-black/40">|</span>
-            <span class="text-black/40">optional extras, CLI batch, retry parity</span>
+            <span class="text-black/40">provider hints and resilient CLI batch mode</span>
           </a>
 
           <!-- Headline -->
@@ -264,15 +264,15 @@
         </div>
       </section>
 
-      <!-- What's new in 0.8.0 -->
+      <!-- What's new in 0.9.0 -->
       <section id="whats-new" class="py-16 sm:py-24 border-t border-black/5 scroll-mt-14">
         <div class="max-w-5xl mx-auto px-4 sm:px-6">
           <div class="flex items-baseline justify-between mb-8 sm:mb-10 flex-wrap gap-3">
             <div>
               <p class="font-mono text-[11px] text-black/40 uppercase tracking-wider mb-2">What&rsquo;s new</p>
-              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.8.0</h2>
+              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.9.0</h2>
             </div>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#080---2026-06-02" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#090---2026-06-21" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
               Full changelog <i data-lucide="arrow-up-right" class="w-3 h-3"></i>
             </a>
           </div>
@@ -282,11 +282,11 @@
               <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
                 <i data-lucide="package" class="w-4 h-4 text-black/40"></i>
               </div>
-              <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">v0.8.0 &middot; Install</span>
+              <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">v0.9.0 &middot; CLI</span>
             </div>
-            <h3 class="font-mono text-base font-medium text-black/90 mb-2">Slim core, optional provider extras</h3>
+            <h3 class="font-mono text-base font-medium text-black/90 mb-2">Resilient CLI batch extraction</h3>
             <p class="text-sm text-black/60 leading-relaxed mb-4">
-              <code class="font-mono text-black/90 text-xs">pip install openextract</code> and <code class="font-mono text-black/90 text-xs">uv add openextract</code> ship a lean dependency set. Add the SDK you need for model calls &mdash; for example <code class="font-mono text-black/90 text-xs">openextract[openai]</code> or <code class="font-mono text-black/90 text-xs">openextract[all]</code>.
+              <code class="font-mono text-black/90 text-xs">openextract --continue-on-error</code> keeps batch jobs moving when one item fails, reports per-item errors inline, and exits <code class="font-mono text-black/90 text-xs">7</code> if any input failed. Missing provider SDKs now produce actionable <code class="font-mono text-black/90 text-xs">pip install openextract[...]</code> hints.
             </p>
             <div class="flex flex-wrap gap-1.5">
               <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[openai]</span>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.8.0"
+version = "0.9.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1229,7 +1229,7 @@ wheels = [
 
 [[package]]
 name = "openextract"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
### Motivation
- Publish the 0.9.0 release by promoting the current unreleased entries (notably provider-install hints and resilient CLI batch behavior) and update packaging/docs to reflect the new version.

### Description
- Bump package version to `0.9.0` and update the lockfile, promote the unreleased changelog entries into a `0.9.0 - 2026-06-21` release, and refresh the landing page messaging; changes touch `pyproject.toml`, `uv.lock`, `CHANGELOG.md`, and `docs/index.html`.

### Testing
- Ran `uv run ruff check .`, `uv run ty check`, and `uv run pytest`, and all checks passed with the test suite result `168 passed, 4 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37565c8b44832ab2c0aaa5f25efa46)