### PR TITLE
Release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ timing when that is known.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-07-17
+
 ### Added
 - Compatibility and deprecation policy documenting the public API surface,
   pre-1.0 breaking-change expectations, provider compatibility limits, and
@@ -123,7 +125,8 @@ timing when that is known.
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.5.0...v0.6.0

--- a/docs/index.html
+++ b/docs/index.html
@@ -93,9 +93,9 @@
           <!-- Badge -->
           <a href="#whats-new" class="animate-slide-up opacity-0 inline-flex items-center gap-2.5 px-3 py-1.5 border border-black/10 bg-white text-xs mb-8 hover:border-black/30 transition-colors">
             <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-            <span class="font-mono text-black/40">v0.8.0</span>
+            <span class="font-mono text-black/40">v0.9.0</span>
             <span class="text-black/40">|</span>
-            <span class="text-black/40">optional extras, CLI batch, retry parity</span>
+            <span class="text-black/40">resilient CLI batches, clearer provider setup</span>
           </a>
 
           <!-- Headline -->
@@ -264,15 +264,15 @@
         </div>
       </section>
 
-      <!-- What's new in 0.8.0 -->
+      <!-- What's new in 0.9.0 -->
       <section id="whats-new" class="py-16 sm:py-24 border-t border-black/5 scroll-mt-14">
         <div class="max-w-5xl mx-auto px-4 sm:px-6">
           <div class="flex items-baseline justify-between mb-8 sm:mb-10 flex-wrap gap-3">
             <div>
               <p class="font-mono text-[11px] text-black/40 uppercase tracking-wider mb-2">What&rsquo;s new</p>
-              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.8.0</h2>
+              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.9.0</h2>
             </div>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#080---2026-06-02" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#090---2026-07-17" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
               Full changelog <i data-lucide="arrow-up-right" class="w-3 h-3"></i>
             </a>
           </div>
@@ -282,20 +282,17 @@
               <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
                 <i data-lucide="package" class="w-4 h-4 text-black/40"></i>
               </div>
-              <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">v0.8.0 &middot; Install</span>
+              <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">v0.9.0 &middot; Reliability</span>
             </div>
-            <h3 class="font-mono text-base font-medium text-black/90 mb-2">Slim core, optional provider extras</h3>
+            <h3 class="font-mono text-base font-medium text-black/90 mb-2">Keep batch work moving, fix setup faster</h3>
             <p class="text-sm text-black/60 leading-relaxed mb-4">
-              <code class="font-mono text-black/90 text-xs">pip install openextract</code> and <code class="font-mono text-black/90 text-xs">uv add openextract</code> ship a lean dependency set. Add the SDK you need for model calls &mdash; for example <code class="font-mono text-black/90 text-xs">openextract[openai]</code> or <code class="font-mono text-black/90 text-xs">openextract[all]</code>.
+              Batch runs can now continue after an individual failure with <code class="font-mono text-black/90 text-xs">--continue-on-error</code>. Missing provider extras produce an actionable install command, and retry and concurrency settings fail early when invalid.
             </p>
             <div class="flex flex-wrap gap-1.5">
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[openai]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[anthropic]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[google]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[bedrock]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[groq]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[mistral]</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">[all]</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">--continue-on-error</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">exit code 6</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">exit code 7</span>
+              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">input validation</span>
             </div>
           </div>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.8.0"
+version = "0.9.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1229,7 +1229,7 @@ wheels = [
 
 [[package]]
 name = "openextract"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
## Summary

Prepare the v0.9.0 release.

## Changes

- Bump the package and lockfile version from 0.8.0 to 0.9.0.
- Move Unreleased notes into the dated v0.9.0 changelog section and refresh comparison links.
- Update the landing page with the latest batch reliability, provider setup, and validation improvements.

## Testing

- `uv sync --dev`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -v --cov=openextract --cov-report=term-missing --cov-fail-under=0` (182 passed, 4 skipped)
- `uv run coverage report --fail-under=100` (100%)
- `uv build`

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)