### PR TITLE
Add ExtractBench runner for any model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ wheels/
 
 # Virtual environments
 .venv
+.extractbench/
 
 # Environment files
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ timing when that is known.
 ## [Unreleased]
 
 ### Added
+- `scripts/extractbench.py` runs [ExtractBench](https://github.com/run-llama/ExtractBench)
+  through openextract with any `pydantic-ai` model identifier (`--model openai:gpt-5 --test`).
 - Typed input and result contracts: `ExtractionInput` supports direct
   `os.PathLike` sources with per-item `media_type` and an optional safe
   `name`, and `ExtractionResult[T]` carries output, usage, attempts, timing,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,18 @@ uv run python scripts/bench.py
 
 It deliberately does **not** measure model or network latency. See [docs/benchmarking.md](docs/benchmarking.md) for what it measures, when to run it, and how to read the output without overfitting to local noise.
 
+## ExtractBench quality eval (any model)
+
+To score openextract on LlamaIndex ExtractBench with any provider model:
+
+```bash
+uv run python scripts/extractbench.py --model openai:gpt-5 --test
+```
+
+The first run bootstraps ExtractBench into `.extractbench/`. This is opt-in,
+makes live model calls, and is not part of default CI. See
+[docs/extractbench.md](docs/extractbench.md).
+
 ## Live provider smoke tests (maintainers)
 
 Default `pytest` does not call live models. To run the opt-in harness:

--- a/README.md
+++ b/README.md
@@ -524,6 +524,15 @@ uv run ty check                            # types (Astral ty)
 
 CI runs the test suite on every PR and fails if total coverage drops below 100%.
 
+To score extraction quality on [ExtractBench](https://github.com/run-llama/ExtractBench)
+with any model:
+
+```bash
+uv run python scripts/extractbench.py --model openai:gpt-5 --test
+```
+
+See [docs/extractbench.md](docs/extractbench.md).
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.
 
 ## Roadmap

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -128,3 +128,10 @@ regression.
 > These measurements are a local diagnostic aid. They are **not** universal
 > performance guarantees and should not be quoted as openextract's performance
 > characteristics.
+
+## Extraction quality (ExtractBench)
+
+For schema-guided extraction accuracy against LlamaIndex ExtractBench, use
+[`scripts/extractbench.py`](extractbench.md) with any `pydantic-ai` model
+identifier. That tool calls live models and is not a substitute for this
+local overhead benchmark.

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -1,0 +1,81 @@
+---
+layout: page
+title: ExtractBench
+---
+
+# ExtractBench (any model)
+
+[`scripts/extractbench.py`](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/scripts/extractbench.py)
+runs [LlamaIndex ExtractBench](https://github.com/run-llama/ExtractBench) through
+openextract. Pass any `pydantic-ai` model identifier; the script registers an
+openextract pipeline, downloads the dataset if needed, runs inference, and
+scores with ExtractBench's official unified value F1.
+
+This is a **quality** benchmark (schema-guided extraction accuracy). It is
+separate from [`scripts/bench.py`](benchmarking.md), which only measures local
+CPU overhead with the model call mocked out.
+
+## Quick start
+
+From the repository root, with provider credentials in `.env` (the same keys
+the CLI and examples use):
+
+```bash
+# 6 documents — good for trying a model (cents on a hosted API)
+uv run python scripts/extractbench.py --model openai:gpt-5 --test
+
+# One length split
+uv run python scripts/extractbench.py --model xai:grok-4.3 --group short
+
+# Full benchmark (370 documents / 4,869 pages — metered API usage)
+uv run python scripts/extractbench.py --model anthropic:claude-sonnet-4
+```
+
+`--model` follows the same `provider:id` convention as `extract()`, for
+example `openai:gpt-5`, `google-gla:gemini-2.5-pro`, `ollama:llama3`, or
+`openrouter:anthropic/claude-sonnet-4`. You can also set `OPENEXTRACT_MODEL`
+instead of passing `--model`.
+
+The first run creates `.extractbench/venv`, installs ExtractBench from GitHub,
+and editable-installs this repo with provider extras. Later runs reuse that
+environment. Override the git source with `OPENEXTRACT_EXTRACTBENCH_GIT`.
+
+## What it costs
+
+A full run is 370 documents. Start with `--test`. ExtractBench's own guidance
+is that hosted VLMs typically cost on the order of tens of dollars for a full
+run; specialized APIs and coding agents cost more. This wrapper records token
+usage; pass `--input-price-per-1m` and `--output-price-per-1m` if you want
+ExtractBench to compute `cost_usd`.
+
+## Output
+
+Results land under `.extractbench/output/<pipeline_name>/` (pipeline names are
+`openextract_<slug>` of the model id, or `--pipeline-name`). After a run:
+
+```bash
+uv run python scripts/extractbench.py --serve openextract_openai_gpt_5
+```
+
+## Other commands
+
+```bash
+uv run python scripts/extractbench.py --install          # bootstrap only
+uv run python scripts/extractbench.py --download-only --test
+uv run python scripts/extractbench.py --status --test
+uv run python scripts/extractbench.py --model openai:gpt-5 --skip-inference
+```
+
+`--max-concurrent` defaults to 4 (ExtractBench's own default is 20). Raise it
+if your provider quota allows. `--max-input-bytes` defaults to 500 MiB so long
+scans are not rejected by openextract's 50 MiB library default.
+
+openextract does not currently return per-field bounding boxes, so ExtractBench
+**grounding** F1 will be zero. Unified **value** F1 is the score this wrapper
+is meant to produce.
+
+## Dataset license
+
+ExtractBench documents come from public records (see the upstream README).
+The harness clones ExtractBench into `.extractbench/` (gitignored) and does
+not vendor those files in this repository.

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -46,7 +46,9 @@ A full run is 370 documents. Start with `--test`. ExtractBench's own guidance
 is that hosted VLMs typically cost on the order of tens of dollars for a full
 run; specialized APIs and coding agents cost more. This wrapper records token
 usage; pass `--input-price-per-1m` and `--output-price-per-1m` if you want
-ExtractBench to compute `cost_usd`.
+ExtractBench to compute `cost_usd`. Reported usage and `cost_usd` cover the
+successful attempt only; tokens spent on failed attempts that were retried
+(`--max-retries`) are not included.
 
 ## Output
 

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -1,0 +1,561 @@
+"""Run LlamaIndex ExtractBench through openextract with any model.
+
+ExtractBench scores schema-guided extraction on 370 enterprise documents.
+This wrapper registers an openextract pipeline so you can evaluate any
+``pydantic-ai`` model identifier without editing ExtractBench itself.
+
+Quick start (6 documents, cents on a hosted API)::
+
+    uv run python scripts/extractbench.py --model openai:gpt-5 --test
+
+Full run (370 documents; metered APIs can cost tens to hundreds of dollars)::
+
+    uv run python scripts/extractbench.py --model xai:grok-4.3
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from dotenv import load_dotenv
+from pydantic import BaseModel, ConfigDict
+
+from openextract import (
+    Extractor,
+    InputTooLargeError,
+    ModelError,
+    ProviderNotInstalledError,
+    RetryPolicy,
+    SchemaValidationError,
+    Usage,
+)
+from openextract._extract import _install_hint, _route_model
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CACHE_DIR = REPO_ROOT / ".extractbench"
+VENV_DIR = CACHE_DIR / "venv"
+EXTRACTBENCH_GIT = os.environ.get(
+    "OPENEXTRACT_EXTRACTBENCH_GIT",
+    "git+https://github.com/run-llama/ExtractBench.git",
+)
+DEFAULT_INSTRUCTIONS = (
+    "You are extracting structured data from a document according to the "
+    "provided JSON schema. Return only the JSON that matches the schema. Use "
+    "null for fields not present in the document. When the schema includes a "
+    "list field, populate every relevant row visible in the document — do not "
+    "return an empty list when rows are present."
+)
+DEFAULT_MAX_INPUT_BYTES = 500 * 1024 * 1024
+_REF_PREFIXES = ("#/$defs/", "#/definitions/")
+
+
+class ExtractedDocument(BaseModel):
+    """Passthrough container so ExtractBench JSON is not strict-revalidated."""
+
+    model_config = ConfigDict(extra="allow")
+
+
+def pipeline_name_for_model(model: str, override: str | None = None) -> str:
+    """Stable ExtractBench pipeline name for a pydantic-ai model id."""
+    if override:
+        return override
+    slug = re.sub(r"[^a-z0-9]+", "_", model.lower()).strip("_")
+    return f"openextract_{slug}" if slug else "openextract"
+
+
+def add_additional_properties_false(schema: dict[str, Any]) -> dict[str, Any]:
+    """Recursively set ``additionalProperties: false`` on every object schema."""
+    out = copy.deepcopy(schema)
+
+    def walk(node: Any) -> None:
+        if isinstance(node, dict):
+            if node.get("type") == "object" or "properties" in node:
+                node["additionalProperties"] = False
+            for value in (node.get("properties") or {}).values():
+                walk(value)
+            if "items" in node:
+                walk(node["items"])
+            for key in ("anyOf", "oneOf", "allOf"):
+                for branch in node.get(key) or []:
+                    walk(branch)
+            for key in ("$defs", "definitions"):
+                for definition in (node.get(key) or {}).values():
+                    walk(definition)
+        elif isinstance(node, list):
+            for item in node:
+                walk(item)
+
+    walk(out)
+    return out
+
+
+def inline_json_schema_defs(schema: dict[str, Any]) -> dict[str, Any]:
+    """Replace local ``$ref`` pointers with the referenced definitions.
+
+    Recursive references are left unresolved so ``StructuredDict`` can fall
+    back to prompt-only schema guidance instead of looping.
+    """
+    out = copy.deepcopy(schema)
+    defs = dict(out.get("$defs") or {})
+    defs.update(out.get("definitions") or {})
+
+    def resolve(node: Any, stack: frozenset[str]) -> Any:
+        if isinstance(node, list):
+            return [resolve(item, stack) for item in node]
+        if not isinstance(node, dict):
+            return node
+        ref = node.get("$ref")
+        if isinstance(ref, str):
+            name = None
+            for prefix in _REF_PREFIXES:
+                if ref.startswith(prefix):
+                    name = ref[len(prefix) :]
+                    break
+            if name is not None and name in defs and name not in stack:
+                merged = copy.deepcopy(defs[name])
+                merged.update({key: value for key, value in node.items() if key != "$ref"})
+                return resolve(merged, stack | {name})
+            return node
+        return {
+            key: resolve(value, stack)
+            for key, value in node.items()
+            if key not in ("$defs", "definitions")
+        }
+
+    return resolve(out, frozenset())
+
+
+def prepare_schema(
+    schema: dict[str, Any], *, additional_properties_false: bool = True
+) -> dict[str, Any]:
+    """Normalize an ExtractBench JSON schema for structured-output calls."""
+    prepared = (
+        add_additional_properties_false(schema)
+        if additional_properties_false
+        else copy.deepcopy(schema)
+    )
+    return inline_json_schema_defs(prepared)
+
+
+def as_extracted_dict(output: object) -> dict[str, Any]:
+    """Return a plain dict from Extractor output without inventing fields."""
+    if isinstance(output, ExtractedDocument):
+        output = output.model_dump()
+    elif isinstance(output, BaseModel):
+        dumped = output.model_dump()
+        output = dumped["root"] if list(dumped.keys()) == ["root"] else dumped
+    if not isinstance(output, dict):
+        raise TypeError(f"Expected dict extraction, got {type(output).__name__}")
+    return output
+
+
+def _output_type_for_schema(schema: dict[str, Any], model: str | object) -> object:
+    try:
+        from pydantic_ai.output import NativeOutput, StructuredDict
+    except ImportError:
+        return ExtractedDocument
+
+    try:
+        output_type: object = StructuredDict(schema, name="extraction")
+    except Exception:
+        return ExtractedDocument
+    if isinstance(model, str) and model.startswith("ollama"):
+        return NativeOutput(output_type)
+    return output_type
+
+
+def _build_schema_agent(model: str | object, schema: dict[str, Any], instructions: str):
+    from pydantic_ai import Agent
+
+    output_type = _output_type_for_schema(schema, model)
+    routed = _route_model(model) if isinstance(model, str) else model
+    try:
+        return Agent(routed, output_type=output_type, instructions=instructions)
+    except ImportError as exc:
+        if isinstance(model, str):
+            message = (
+                f"Model {model!r} needs a provider SDK that is not installed. "
+                f"Install it with: {_install_hint(model)} "
+                f"(or 'pip install openextract[all]'). Original error: {exc}"
+            )
+        else:
+            message = f"The configured model needs a provider SDK that is not installed: {exc}"
+        raise ProviderNotInstalledError(message) from exc
+
+
+def extract_document(
+    source: Path | str | bytes,
+    json_schema: dict[str, Any],
+    model: str | object,
+    *,
+    instructions: str = DEFAULT_INSTRUCTIONS,
+    media_type: str | None = None,
+    max_retries: int = 2,
+    max_input_bytes: int | None = DEFAULT_MAX_INPUT_BYTES,
+    additional_properties_false: bool = True,
+) -> tuple[dict[str, Any], Usage]:
+    """Extract one document with openextract using an ExtractBench JSON schema."""
+    schema = prepare_schema(json_schema, additional_properties_false=additional_properties_false)
+    agent = _build_schema_agent(model, schema, instructions)
+    policy = RetryPolicy(max_retries=max_retries)
+    with Extractor(
+        ExtractedDocument,
+        agent=agent,
+        retry_policy=policy,
+        max_input_bytes=max_input_bytes,
+    ) as extractor:
+        output, usage = extractor.extract_with_usage(source, media_type=media_type)
+    return as_extracted_dict(output), usage
+
+
+def _venv_python() -> Path:
+    return VENV_DIR / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def extract_bench_available() -> bool:
+    import importlib.util
+
+    return importlib.util.find_spec("extract_bench") is not None
+
+
+def _run(command: list[str]) -> None:
+    subprocess.run(command, check=True)
+
+
+def ensure_extract_bench(*, reexec: bool = True) -> None:
+    """Install ExtractBench into ``.extractbench/venv`` when it is not importable."""
+    if extract_bench_available():
+        return
+    python = _venv_python()
+    if Path(sys.executable).resolve() != python.resolve():
+        CACHE_DIR.mkdir(parents=True, exist_ok=True)
+        if not python.exists():
+            print(f"Creating ExtractBench environment at {VENV_DIR}", file=sys.stderr)
+            _run(["uv", "venv", str(VENV_DIR)])
+        print("Installing ExtractBench and openextract (first run only)...", file=sys.stderr)
+        _run(
+            [
+                "uv",
+                "pip",
+                "install",
+                "--python",
+                str(python),
+                "--no-config",
+                EXTRACTBENCH_GIT,
+                "-e",
+                f"{REPO_ROOT}[all]",
+            ]
+        )
+        if not reexec:
+            return
+        os.execv(str(python), [str(python), str(Path(__file__).resolve()), *sys.argv[1:]])
+    raise RuntimeError(
+        "extract_bench is not importable. Re-run with network access so the "
+        f"script can install {EXTRACTBENCH_GIT} into {VENV_DIR}."
+    )
+
+
+def register_openextract_pipeline(
+    model: str,
+    *,
+    pipeline_name: str | None = None,
+    instructions: str = DEFAULT_INSTRUCTIONS,
+    max_retries: int = 2,
+    max_input_bytes: int | None = DEFAULT_MAX_INPUT_BYTES,
+    additional_properties_false: bool = True,
+    input_price_per_1m: float = 0.0,
+    output_price_per_1m: float = 0.0,
+) -> str:
+    """Register the openextract ExtractBench provider and pipeline; return its name."""
+    from extract_bench.inference.pipelines import get_pipeline, register_pipeline
+    from extract_bench.inference.providers.base import (
+        Provider,
+        ProviderConfigError,
+        ProviderPermanentError,
+        ProviderTransientError,
+    )
+    from extract_bench.inference.providers.registry import (
+        _PROVIDER_REGISTRY,
+        register_provider,
+    )
+    from extract_bench.schemas.extract_output import ExtractOutput
+    from extract_bench.schemas.pipeline import PipelineSpec
+    from extract_bench.schemas.pipeline_io import (
+        InferenceRequest,
+        InferenceResult,
+        RawInferenceResult,
+    )
+    from extract_bench.schemas.product import ProductType
+
+    name = pipeline_name_for_model(model, pipeline_name)
+    config = {
+        "model": model,
+        "instructions": instructions,
+        "max_retries": max_retries,
+        "max_input_bytes": max_input_bytes,
+        "additional_properties_false": additional_properties_false,
+        "input_price_per_1m": input_price_per_1m,
+        "output_price_per_1m": output_price_per_1m,
+    }
+
+    if "openextract" not in _PROVIDER_REGISTRY:
+
+        class OpenExtractProvider(Provider):
+            def run_inference(
+                self, pipeline: PipelineSpec, request: InferenceRequest
+            ) -> RawInferenceResult:
+                from datetime import datetime
+
+                if request.product_type != ProductType.EXTRACT:
+                    raise ProviderPermanentError(
+                        f"openextract only supports EXTRACT, got {request.product_type}"
+                    )
+                schema = request.schema_override
+                if not schema:
+                    raise ProviderPermanentError("schema_override is required for EXTRACT")
+                source = Path(request.source_file_path)
+                if not source.exists():
+                    raise ProviderPermanentError(f"File not found: {source}")
+
+                cfg = self.base_config
+                started_at = datetime.now()
+                try:
+                    extracted, usage = extract_document(
+                        source,
+                        schema,
+                        cfg["model"],
+                        instructions=cfg.get("instructions", DEFAULT_INSTRUCTIONS),
+                        max_retries=int(cfg.get("max_retries", 2)),
+                        max_input_bytes=cfg.get("max_input_bytes"),
+                        additional_properties_false=bool(
+                            cfg.get("additional_properties_false", True)
+                        ),
+                    )
+                except ProviderNotInstalledError as exc:
+                    raise ProviderConfigError(str(exc)) from exc
+                except ModelError as exc:
+                    if exc.retryable:
+                        raise ProviderTransientError(str(exc)) from exc
+                    raise ProviderPermanentError(str(exc)) from exc
+                except (SchemaValidationError, InputTooLargeError, TypeError) as exc:
+                    raise ProviderPermanentError(str(exc)) from exc
+
+                completed_at = datetime.now()
+                in_tok = usage.input_tokens
+                out_tok = usage.output_tokens
+                cost_usd = in_tok / 1_000_000 * float(
+                    cfg.get("input_price_per_1m", 0.0)
+                ) + out_tok / 1_000_000 * float(cfg.get("output_price_per_1m", 0.0))
+                raw_output = {
+                    "data": extracted,
+                    "model": cfg["model"],
+                    "usage": {
+                        "input_tokens": in_tok,
+                        "output_tokens": out_tok,
+                        "total_tokens": usage.total_tokens,
+                    },
+                    "cost_usd": cost_usd,
+                }
+                return RawInferenceResult(
+                    request=request,
+                    pipeline=pipeline,
+                    pipeline_name=pipeline.pipeline_name,
+                    product_type=request.product_type,
+                    raw_output=raw_output,
+                    started_at=started_at,
+                    completed_at=completed_at,
+                    latency_in_ms=int((completed_at - started_at).total_seconds() * 1000),
+                )
+
+            def normalize(self, raw_result: RawInferenceResult) -> InferenceResult:
+                extracted = raw_result.raw_output.get("data") or {}
+                return InferenceResult(
+                    request=raw_result.request,
+                    pipeline_name=raw_result.pipeline_name,
+                    product_type=raw_result.product_type,
+                    raw_output=raw_result.raw_output,
+                    output=ExtractOutput(
+                        task_type="extract",
+                        example_id=raw_result.request.example_id,
+                        pipeline_name=raw_result.pipeline_name,
+                        extracted_data=extracted,
+                        field_citations=[],
+                    ),
+                    started_at=raw_result.started_at,
+                    completed_at=raw_result.completed_at,
+                    latency_in_ms=raw_result.latency_in_ms,
+                )
+
+        register_provider("openextract")(OpenExtractProvider)
+
+    try:
+        spec = get_pipeline(name)
+        spec.config.update(config)
+    except ValueError:
+        register_pipeline(
+            PipelineSpec(
+                pipeline_name=name,
+                provider_name="openextract",
+                product_type=ProductType.EXTRACT,
+                config=config,
+            )
+        )
+    return name
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run ExtractBench through openextract with any pydantic-ai model.",
+    )
+    parser.add_argument(
+        "--model",
+        "-m",
+        help="pydantic-ai model id, e.g. openai:gpt-5, xai:grok-4.3, ollama:llama3",
+    )
+    parser.add_argument(
+        "--test",
+        action="store_true",
+        help="6-document test split (recommended first run)",
+    )
+    parser.add_argument("--group", choices=("short", "medium", "long"), help="run one length split")
+    parser.add_argument("--file", help="run a single PDF/image instead of the dataset")
+    parser.add_argument(
+        "--max-concurrent", type=int, default=4, help="parallel documents (default: 4)"
+    )
+    parser.add_argument("--max-retries", type=int, default=2, help="transient ModelError retries")
+    parser.add_argument(
+        "--max-input-bytes",
+        type=int,
+        default=DEFAULT_MAX_INPUT_BYTES,
+        help="per-document byte cap (default: 500 MiB)",
+    )
+    parser.add_argument("--pipeline-name", help="override the auto-generated pipeline name")
+    parser.add_argument(
+        "--data-dir", type=Path, help="dataset directory (default: .extractbench/data)"
+    )
+    parser.add_argument(
+        "--output-dir", type=Path, help="results directory (default: .extractbench/output)"
+    )
+    parser.add_argument(
+        "--force", action="store_true", help="re-run inference even if results exist"
+    )
+    parser.add_argument(
+        "--skip-inference", action="store_true", help="re-evaluate existing results only"
+    )
+    parser.add_argument(
+        "--open-report", action="store_true", help="open the HTML report when finished"
+    )
+    parser.add_argument("--verbose", action="store_true")
+    parser.add_argument(
+        "--no-additional-properties-false",
+        action="store_true",
+        help="do not close object schemas with additionalProperties: false",
+    )
+    parser.add_argument(
+        "--input-price-per-1m", type=float, default=0.0, help="USD per million input tokens"
+    )
+    parser.add_argument(
+        "--output-price-per-1m", type=float, default=0.0, help="USD per million output tokens"
+    )
+    parser.add_argument(
+        "--install", action="store_true", help="only bootstrap the ExtractBench environment"
+    )
+    parser.add_argument(
+        "--download-only", action="store_true", help="download the dataset and exit"
+    )
+    parser.add_argument(
+        "--serve",
+        nargs="?",
+        const="",
+        metavar="PIPELINE",
+        help="serve HTML reports (optionally for a pipeline name)",
+    )
+    parser.add_argument("--status", action="store_true", help="print dataset download status")
+    return parser.parse_args(argv)
+
+
+def _require_model(args: argparse.Namespace) -> str:
+    model = args.model or os.environ.get("OPENEXTRACT_MODEL")
+    if not model:
+        print(
+            "error: --model is required (or set OPENEXTRACT_MODEL). Example: --model openai:gpt-5",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return model
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    load_dotenv(REPO_ROOT / ".env", override=False)
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+
+    ensure_extract_bench()
+    if args.install:
+        print(f"ExtractBench ready ({CACHE_DIR})")
+        return 0
+
+    from extract_bench.cli import BenchCLI
+
+    if args.data_dir is not None:
+        args.data_dir = args.data_dir.expanduser().resolve()
+    if args.output_dir is not None:
+        args.output_dir = args.output_dir.expanduser().resolve()
+    if args.file is not None:
+        args.file = str(Path(args.file).expanduser().resolve())
+
+    cli = BenchCLI()
+    os.chdir(CACHE_DIR)
+    if args.download_only:
+        return int(cli.download(data_dir=args.data_dir, test=args.test) or 0)
+    if args.status:
+        return int(cli.status(data_dir=args.data_dir, test=args.test) or 0)
+    if args.serve is not None:
+        return int(cli.serve(pipeline=args.serve or None) or 0)
+
+    model = _require_model(args)
+    name = register_openextract_pipeline(
+        model,
+        pipeline_name=args.pipeline_name,
+        max_retries=args.max_retries,
+        max_input_bytes=args.max_input_bytes,
+        additional_properties_false=not args.no_additional_properties_false,
+        input_price_per_1m=args.input_price_per_1m,
+        output_price_per_1m=args.output_price_per_1m,
+    )
+    print(f"Pipeline: {name}")
+    print(f"Model:    {model}")
+    if args.test:
+        print("Split:    test (6 documents)")
+    elif args.group:
+        print(f"Split:    {args.group}")
+    else:
+        print("Split:    full ExtractBench (370 documents — this is metered API usage)")
+
+    return int(
+        cli.run(
+            pipeline=name,
+            input_dir=args.data_dir,
+            file=args.file,
+            output_dir=args.output_dir,
+            max_concurrent=args.max_concurrent,
+            force=args.force,
+            verbose=args.verbose,
+            group=args.group,
+            open_report=args.open_report,
+            skip_inference=args.skip_inference,
+            test=args.test,
+        )
+        or 0
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -41,9 +41,12 @@ from openextract._extract import _install_hint, _route_model
 REPO_ROOT = Path(__file__).resolve().parents[1]
 CACHE_DIR = REPO_ROOT / ".extractbench"
 VENV_DIR = CACHE_DIR / "venv"
+# Pinned to a commit so scores stay comparable across bootstraps and upstream
+# changes cannot break the runner (it reaches into private ExtractBench
+# internals). Bump the SHA deliberately when adopting a newer ExtractBench.
 EXTRACTBENCH_GIT = os.environ.get(
     "OPENEXTRACT_EXTRACTBENCH_GIT",
-    "git+https://github.com/run-llama/ExtractBench.git",
+    "git+https://github.com/run-llama/ExtractBench.git@28dadf58fcd1ab366808ac8e2dfc8716fa9ad5aa",
 )
 DEFAULT_INSTRUCTIONS = (
     "You are extracting structured data from a document according to the "
@@ -157,15 +160,32 @@ def as_extracted_dict(output: object) -> dict[str, Any]:
 
 
 def _output_type_for_schema(schema: dict[str, Any], model: str | object) -> object:
+    """Build the structured output type for a schema, refusing to degrade.
+
+    Running schema-less while the prompt references "the provided JSON schema"
+    would produce a near-zero score misattributed to the model, so any failure
+    here is a permanent, loudly-reported error rather than a silent fallback.
+    """
+    schema_name = schema.get("title") or "extraction"
     try:
         from pydantic_ai.output import NativeOutput, StructuredDict
-    except ImportError:
-        return ExtractedDocument
+    except ImportError as exc:
+        message = (
+            f"Cannot build structured output for schema {schema_name!r}: this "
+            f"pydantic-ai version lacks StructuredDict ({exc}). Upgrade pydantic-ai."
+        )
+        print(f"warning: {message}", file=sys.stderr)
+        raise SchemaValidationError(message) from exc
 
     try:
         output_type: object = StructuredDict(schema, name="extraction")
-    except Exception:
-        return ExtractedDocument
+    except Exception as exc:
+        message = (
+            f"JSON schema {schema_name!r} could not be converted into a "
+            f"structured output type: {exc}"
+        )
+        print(f"warning: {message}", file=sys.stderr)
+        raise SchemaValidationError(message) from exc
     if isinstance(model, str) and model.startswith("ollama"):
         return NativeOutput(output_type)
     return output_type
@@ -229,16 +249,45 @@ def _run(command: list[str]) -> None:
     subprocess.run(command, check=True)
 
 
+def _inside_benchmark_venv() -> bool:
+    """True when this interpreter runs from ``.extractbench/venv``.
+
+    Compares ``sys.prefix`` to the venv directory instead of resolving
+    executables: under uv both the project and benchmark interpreters are
+    symlinks to the same base Python, so resolved executable paths are equal
+    even when the venvs differ.
+    """
+    return Path(sys.prefix).resolve() == VENV_DIR.resolve()
+
+
+def _venv_has_extract_bench(python: Path) -> bool:
+    """Probe the benchmark venv for an importable ``extract_bench``."""
+    if not python.exists():
+        return False
+    probe = subprocess.run(
+        [str(python), "-c", "import extract_bench"],
+        capture_output=True,
+        check=False,
+    )
+    return probe.returncode == 0
+
+
 def ensure_extract_bench(*, reexec: bool = True) -> None:
     """Install ExtractBench into ``.extractbench/venv`` when it is not importable."""
     if extract_bench_available():
         return
+    if _inside_benchmark_venv():
+        raise RuntimeError(
+            "extract_bench is not importable from the benchmark environment. "
+            f"Delete {VENV_DIR} and re-run with network access so the script "
+            f"can reinstall {EXTRACTBENCH_GIT}."
+        )
     python = _venv_python()
-    if Path(sys.executable).resolve() != python.resolve():
-        CACHE_DIR.mkdir(parents=True, exist_ok=True)
-        if not python.exists():
-            print(f"Creating ExtractBench environment at {VENV_DIR}", file=sys.stderr)
-            _run(["uv", "venv", str(VENV_DIR)])
+    CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    if not python.exists():
+        print(f"Creating ExtractBench environment at {VENV_DIR}", file=sys.stderr)
+        _run(["uv", "venv", str(VENV_DIR)])
+    if not _venv_has_extract_bench(python):
         print("Installing ExtractBench and openextract (first run only)...", file=sys.stderr)
         _run(
             [
@@ -253,13 +302,9 @@ def ensure_extract_bench(*, reexec: bool = True) -> None:
                 f"{REPO_ROOT}[all]",
             ]
         )
-        if not reexec:
-            return
-        os.execv(str(python), [str(python), str(Path(__file__).resolve()), *sys.argv[1:]])
-    raise RuntimeError(
-        "extract_bench is not importable. Re-run with network access so the "
-        f"script can install {EXTRACTBENCH_GIT} into {VENV_DIR}."
-    )
+    if not reexec:
+        return
+    os.execv(str(python), [str(python), str(Path(__file__).resolve()), *sys.argv[1:]])
 
 
 def register_openextract_pipeline(

--- a/tests/test_extractbench.py
+++ b/tests/test_extractbench.py
@@ -1,0 +1,139 @@
+"""Tests for scripts/extractbench.py (offline; no ExtractBench install required)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+from pydantic_ai.models.test import TestModel
+
+SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+import extractbench  # noqa: E402
+
+
+def test_pipeline_name_for_model_slugs_provider_prefix():
+    assert extractbench.pipeline_name_for_model("openai:gpt-5") == "openextract_openai_gpt_5"
+    assert extractbench.pipeline_name_for_model("xai:grok-4.3") == "openextract_xai_grok_4_3"
+    assert extractbench.pipeline_name_for_model("openai:gpt-5", "custom") == "custom"
+
+
+def test_add_additional_properties_false_closes_nested_objects():
+    schema = {
+        "type": "object",
+        "properties": {
+            "vendor": {"type": "string"},
+            "lines": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {"qty": {"type": "integer"}},
+                },
+            },
+        },
+        "$defs": {"Addr": {"type": "object", "properties": {"city": {"type": "string"}}}},
+    }
+    out = extractbench.add_additional_properties_false(schema)
+    assert out["additionalProperties"] is False
+    assert out["properties"]["lines"]["items"]["additionalProperties"] is False
+    assert out["$defs"]["Addr"]["additionalProperties"] is False
+    assert schema.get("additionalProperties") is None
+
+
+def test_inline_json_schema_defs_resolves_local_refs():
+    schema = {
+        "type": "object",
+        "properties": {"addr": {"$ref": "#/$defs/Addr"}},
+        "$defs": {
+            "Addr": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+            }
+        },
+    }
+    out = extractbench.inline_json_schema_defs(schema)
+    assert "$defs" not in out
+    assert out["properties"]["addr"]["properties"]["city"]["type"] == "string"
+
+
+def test_inline_json_schema_defs_leaves_recursive_refs():
+    schema = {
+        "type": "object",
+        "properties": {"child": {"$ref": "#/$defs/Node"}},
+        "$defs": {
+            "Node": {
+                "type": "object",
+                "properties": {"child": {"$ref": "#/$defs/Node"}},
+            }
+        },
+    }
+    out = extractbench.inline_json_schema_defs(schema)
+    assert out["properties"]["child"]["properties"]["child"]["$ref"] == "#/$defs/Node"
+
+
+def test_as_extracted_dict_from_passthrough_model():
+    output = extractbench.ExtractedDocument.model_validate({"vendor": "Acme", "total": 1.5})
+    assert extractbench.as_extracted_dict(output) == {"vendor": "Acme", "total": 1.5}
+
+
+def test_as_extracted_dict_rejects_non_objects():
+    with pytest.raises(TypeError, match="Expected dict"):
+        extractbench.as_extracted_dict("not-json")
+
+
+def test_extract_document_with_test_model():
+    schema = {
+        "type": "object",
+        "properties": {
+            "vendor": {"type": "string"},
+            "total": {"type": "number"},
+        },
+        "required": ["vendor", "total"],
+    }
+    model = TestModel(custom_output_args={"vendor": "Acme", "total": 12.5})
+    data, usage = extractbench.extract_document(
+        b"%PDF-fixture",
+        schema,
+        model,
+        media_type="application/pdf",
+        max_retries=0,
+    )
+    assert data["vendor"] == "Acme"
+    assert data["total"] == 12.5
+    assert usage.input_tokens >= 0
+
+
+def test_parse_args_test_split_and_model():
+    args = extractbench.parse_args(["--model", "openai:gpt-5", "--test"])
+    assert args.model == "openai:gpt-5"
+    assert args.test is True
+    assert args.max_concurrent == 4
+
+
+def test_parse_args_serve_without_name():
+    args = extractbench.parse_args(["--serve"])
+    assert args.serve == ""
+
+
+def test_require_model_uses_env(monkeypatch):
+    monkeypatch.setenv("OPENEXTRACT_MODEL", "xai:grok-4.3")
+    args = extractbench.parse_args(["--test"])
+    assert extractbench._require_model(args) == "xai:grok-4.3"
+
+
+def test_require_model_exits_without_model(monkeypatch, capsys):
+    monkeypatch.delenv("OPENEXTRACT_MODEL", raising=False)
+    args = extractbench.parse_args(["--test"])
+    with pytest.raises(SystemExit) as exc:
+        extractbench._require_model(args)
+    assert exc.value.code == 2
+    assert "--model is required" in capsys.readouterr().err
+
+
+def test_main_install_bootstraps_without_model(monkeypatch, capsys):
+    monkeypatch.setattr(extractbench, "ensure_extract_bench", lambda: None)
+    assert extractbench.main(["--install"]) == 0
+    assert "ExtractBench ready" in capsys.readouterr().out

--- a/tests/test_extractbench.py
+++ b/tests/test_extractbench.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 import pytest
 from pydantic_ai.models.test import TestModel
+
+from openextract import SchemaValidationError
 
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 if str(SCRIPTS) not in sys.path:
@@ -104,6 +107,88 @@ def test_extract_document_with_test_model():
     assert data["vendor"] == "Acme"
     assert data["total"] == 12.5
     assert usage.input_tokens >= 0
+
+
+def test_output_type_for_schema_raises_instead_of_degrading(capsys):
+    schema = {"title": "InvoiceList", "type": "array", "items": {"type": "object"}}
+    with pytest.raises(SchemaValidationError, match="InvoiceList"):
+        extractbench._output_type_for_schema(schema, "openai:gpt-5")
+    assert "InvoiceList" in capsys.readouterr().err
+
+
+def test_extract_document_rejects_unconvertible_schema(capsys):
+    model = TestModel(custom_output_args={"vendor": "Acme"})
+    with pytest.raises(SchemaValidationError):
+        extractbench.extract_document(
+            b"%PDF-fixture",
+            {"type": "array", "items": {"type": "string"}},
+            model,
+            media_type="application/pdf",
+            max_retries=0,
+        )
+    assert "warning:" in capsys.readouterr().err
+
+
+def _fake_venv(tmp_path: Path) -> tuple[Path, Path]:
+    venv_dir = tmp_path / "venv"
+    python = venv_dir / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+    python.parent.mkdir(parents=True)
+    python.touch()
+    return venv_dir, python
+
+
+def _patch_bootstrap(monkeypatch, tmp_path: Path, venv_dir: Path) -> list[list[str]]:
+    monkeypatch.setattr(extractbench, "CACHE_DIR", tmp_path)
+    monkeypatch.setattr(extractbench, "VENV_DIR", venv_dir)
+    monkeypatch.setattr(extractbench, "extract_bench_available", lambda: False)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(extractbench, "_run", commands.append)
+    return commands
+
+
+def test_inside_benchmark_venv_compares_sys_prefix(monkeypatch, tmp_path):
+    """Membership uses sys.prefix, not resolved executables (uv symlinks alias)."""
+    venv_dir = tmp_path / "venv"
+    monkeypatch.setattr(extractbench, "VENV_DIR", venv_dir)
+    monkeypatch.setattr(sys, "prefix", str(venv_dir))
+    assert extractbench._inside_benchmark_venv() is True
+    monkeypatch.setattr(sys, "prefix", str(tmp_path / "other-venv"))
+    assert extractbench._inside_benchmark_venv() is False
+
+
+def test_ensure_extract_bench_raises_inside_broken_benchmark_venv(monkeypatch, tmp_path):
+    venv_dir, _python = _fake_venv(tmp_path)
+    commands = _patch_bootstrap(monkeypatch, tmp_path, venv_dir)
+    monkeypatch.setattr(sys, "prefix", str(venv_dir))
+    with pytest.raises(RuntimeError, match="not importable"):
+        extractbench.ensure_extract_bench()
+    assert commands == []
+
+
+def test_ensure_extract_bench_skips_install_when_already_present(monkeypatch, tmp_path):
+    venv_dir, python = _fake_venv(tmp_path)
+    commands = _patch_bootstrap(monkeypatch, tmp_path, venv_dir)
+    monkeypatch.setattr(extractbench, "_venv_has_extract_bench", lambda _python: True)
+    monkeypatch.setattr(sys, "argv", ["extractbench.py"])
+    execs: list[tuple] = []
+    monkeypatch.setattr(os, "execv", lambda *call: execs.append(call))
+    extractbench.ensure_extract_bench()
+    assert commands == []
+    assert execs == [(str(python), [str(python), str(SCRIPTS / "extractbench.py")])]
+
+
+def test_ensure_extract_bench_installs_when_probe_fails(monkeypatch, tmp_path):
+    venv_dir, python = _fake_venv(tmp_path)
+    commands = _patch_bootstrap(monkeypatch, tmp_path, venv_dir)
+    monkeypatch.setattr(extractbench, "_venv_has_extract_bench", lambda _python: False)
+    extractbench.ensure_extract_bench(reexec=False)
+    assert len(commands) == 1
+    assert extractbench.EXTRACTBENCH_GIT in commands[0]
+    assert str(python) in commands[0]
+
+
+def test_venv_has_extract_bench_false_when_python_missing(tmp_path):
+    assert extractbench._venv_has_extract_bench(tmp_path / "missing") is False
 
 
 def test_parse_args_test_split_and_model():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `scripts/extractbench.py` so you can run [LlamaIndex ExtractBench](https://github.com/run-llama/ExtractBench) through openextract with any `pydantic-ai` model identifier.

```bash
uv run python scripts/extractbench.py --model openai:gpt-5 --test
```

## Changes

- New runner bootstraps ExtractBench into `.extractbench/` (isolated venv, gitignored), registers an openextract pipeline, downloads the dataset, and scores with ExtractBench's official unified value F1.
- `--model` accepts the same `provider:id` strings as `extract()` (`openai:gpt-5`, `xai:grok-4.3`, `ollama:llama3`, OpenRouter, …). `OPENEXTRACT_MODEL` works as a fallback.
- JSON schemas are passed through pydantic-ai `StructuredDict` so ExtractBench's schema is what the model sees; output is not strict-revalidated into a generated Pydantic model (that would turn near-misses into score-zero failures).
- Docs: `docs/extractbench.md`, plus pointers from README, CONTRIBUTING, and `docs/benchmarking.md`.

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -v` (410 passed, 5 skipped, 100% coverage)
- Offline unit tests in `tests/test_extractbench.py` cover schema prep, TestModel extraction, CLI parsing, and `--install` without a live ExtractBench download.

Live ExtractBench runs are opt-in and not part of CI (they call metered APIs). Start with `--test` (6 documents).

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff959-1b75-786e-b134-513e4d007fff?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff959-1b75-786e-b134-513e4d007fff&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

