### PR TITLE
ci: run only the jobs a change set needs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,45 +5,107 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
 
 jobs:
-  lint:
+  changes:
+    name: Detect changes
     runs-on: ubuntu-latest
+    timeout-minutes: 3
+    outputs:
+      lint: ${{ steps.filter.outputs.lint }}
+      test: ${{ steps.filter.outputs.test }}
+      package: ${{ steps.filter.outputs.package }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect required jobs
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: python3 scripts/ci_needed.py
+
+  lint:
+    needs: changes
+    if: needs.changes.outputs.lint == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      UV_FROZEN: "1"
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
+        with:
+          enable-cache: true
       - run: uv sync --dev
-      - run: uv run ruff check .
-      - run: uv run ruff format --check .
-      - run: uv run ty check
-      - run: uv run python scripts/check_api_reference.py
+      - run: uv run --no-sync ruff check .
+      - run: uv run --no-sync ruff format --check .
+      - run: uv run --no-sync ty check
+      - run: uv run --no-sync python scripts/check_api_reference.py
 
   test:
     name: Test (Python ${{ matrix.python-version }})
+    needs: changes
+    if: needs.changes.outputs.test == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      UV_FROZEN: "1"
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12", "3.13"]
+        include:
+          - python-version: "3.12"
+            coverage: true
+          - python-version: "3.13"
+            coverage: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
         with:
           python-version: ${{ matrix.python-version }}
+          enable-cache: true
       - run: uv sync --dev
-      - name: Run tests
-        run: uv run pytest -v --cov=openextract --cov-report=term-missing --cov-fail-under=0
+      - name: Run tests with coverage
+        if: matrix.coverage
+        run: uv run --no-sync pytest -v --cov=openextract --cov-report=term-missing --cov-fail-under=0
       - name: Check coverage threshold
-        run: uv run coverage report --fail-under=100
+        if: matrix.coverage
+        run: uv run --no-sync coverage report --fail-under=100
+      - name: Run tests
+        if: ${{ !matrix.coverage }}
+        run: uv run --no-sync pytest -v
 
   package:
     name: Build and install distributions
+    needs: changes
+    if: needs.changes.outputs.package == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
         with:
           python-version: "3.12"
+          enable-cache: true
       - run: uv build
       - name: Smoke-test wheel
         run: |
@@ -57,3 +119,38 @@ jobs:
           uv pip install --python .venv-sdist/bin/python dist/*.tar.gz
           .venv-sdist/bin/python -c "import openextract; assert callable(openextract.extract)"
           .venv-sdist/bin/openextract --help
+
+  ci:
+    name: CI
+    needs: [changes, lint, test, package]
+    if: always() && !cancelled()
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check required jobs
+        env:
+          CHANGES: ${{ needs.changes.result }}
+          LINT: ${{ needs.lint.result }}
+          TEST: ${{ needs.test.result }}
+          PACKAGE: ${{ needs.package.result }}
+        run: |
+          python3 - <<'PY'
+          import os
+          import sys
+
+          results = {
+              "changes": os.environ["CHANGES"],
+              "lint": os.environ["LINT"],
+              "test": os.environ["TEST"],
+              "package": os.environ["PACKAGE"],
+          }
+          allowed = {"success", "skipped"}
+          failed = [name for name, result in results.items() if result not in allowed]
+          print("job results:", results)
+          if results["changes"] != "success":
+              print("Change detection must succeed")
+              sys.exit(1)
+          if failed:
+              print("Failed jobs:", ", ".join(failed))
+              sys.exit(1)
+          PY

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         id: filter
         env:
           EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
           HEAD_SHA: ${{ github.sha }}
         run: python3 scripts/ci_needed.py
 
@@ -123,7 +123,7 @@ jobs:
   ci:
     name: CI
     needs: [changes, lint, test, package]
-    if: always() && !cancelled()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,11 +1,11 @@
 name: Deploy static content to Pages
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
-
-  # Allows you to run this workflow manually from the Actions tab
+    paths:
+      - "docs/**"
+      - ".github/workflows/deploy-docs.yml"
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -27,9 +27,12 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          persist-credentials: false
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5.0.0
       - name: Upload artifact

--- a/.github/workflows/embargo-bump.yml
+++ b/.github/workflows/embargo-bump.yml
@@ -12,12 +12,19 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: embargo-bump
+  cancel-in-progress: true
+
 jobs:
   bump:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
+        with:
+          enable-cache: true
 
       - name: Compute new cutoff (24h ago, UTC midnight)
         id: cutoff

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows: [CI]
     types: [completed]
+    branches: [main]
 
 concurrency:
   group: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,46 +1,67 @@
 name: Release
 
 on:
-  push:
-    branches: [main]
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   release:
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       id-token: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
-          fetch-depth: 0
-
-      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Get version from pyproject.toml
         id: version
         run: |
           VERSION=$(grep -Po '(?<=^version = ")[^"]*' pyproject.toml)
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "tag=v$VERSION" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Check if release exists
         id: check_release
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          VERSION=${{ steps.version.outputs.version }}
-          # Check git tag
-          if git rev-parse "v$VERSION" >/dev/null 2>&1; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Tag v$VERSION already exists"
+          if git ls-remote --exit-code --tags origin "refs/tags/v${VERSION}"; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag v${VERSION} already exists"
             exit 0
           fi
-          # Check PyPI
-          if curl -s "https://pypi.org/pypi/openextract/$VERSION/json" | grep -q '"version"'; then
-            echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Version $VERSION already exists on PyPI"
+          http_code=$(curl -sS -o /tmp/pypi.json -w "%{http_code}" \
+            "https://pypi.org/pypi/openextract/${VERSION}/json")
+          if [ "$http_code" = "200" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Version ${VERSION} already exists on PyPI"
+          elif [ "$http_code" = "404" ]; then
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "PyPI lookup failed with HTTP ${http_code}"
+            exit 1
           fi
+
+      - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
+        if: steps.check_release.outputs.exists == 'false'
+        with:
+          enable-cache: true
 
       - name: Build package
         if: steps.check_release.outputs.exists == 'false'
@@ -57,3 +78,4 @@ jobs:
           tag_name: ${{ steps.version.outputs.tag }}
           name: ${{ steps.version.outputs.tag }}
           generate_release_notes: true
+          target_commitish: ${{ github.event.workflow_run.head_sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ timing when that is known.
   completion order without waiting for the full batch.
 
 ### Changed
+- CI skips jobs that the change set cannot affect, cancels outdated pull-request
+  runs, caches uv downloads, and collects coverage on Python 3.12 only. Releases
+  publish only after CI succeeds on `main`, and docs deploy only when `docs/`
+  changes.
 - `openai:` model identifiers now use the OpenAI Responses API by default;
   `openai-chat:` remains available as an explicit Chat Completions opt-in.
 - Batch execution now schedules at most `max_concurrency` inputs, consumes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,15 @@ uv run ruff format .
 uv run ty check
 ```
 
+## CI
+
+GitHub Actions (`.github/workflows/ci.yml`) runs lint, tests, and package smoke
+tests. Jobs that a change set cannot affect are skipped (for example a
+docs-only PR does not install Python dependencies). Outdated pull-request runs
+are cancelled when a new commit is pushed. After CI succeeds on `main`,
+[`.github/workflows/release.yml`](.github/workflows/release.yml) publishes to
+PyPI only when the version in `pyproject.toml` is new.
+
 ## Dependency embargo (24h)
 
 We do **not** install any package version that has been published less than 24 hours ago. This protects against supply-chain attacks where a compromised release sits on PyPI for a few hours before being yanked.
@@ -94,8 +103,8 @@ See [docs/live-smoke.md](docs/live-smoke.md).
 
 ## Release checklist (maintainers)
 
-Use this before cutting a release (version bump on `main` triggers
-[`.github/workflows/release.yml`](.github/workflows/release.yml)):
+Use this before cutting a release (a version bump on `main` publishes only after
+CI is green — [`.github/workflows/release.yml`](.github/workflows/release.yml)):
 
 1. **Version bump** — set `version` in `pyproject.toml` to the release version.
 2. **Changelog** — move `[Unreleased]` notes into a dated `## [X.Y.Z]` section in
@@ -115,9 +124,10 @@ Use this before cutting a release (version bump on `main` triggers
    rolling 24h window (merge recent `embargo-bump` PRs from
    `.github/workflows/embargo-bump.yml` rather than hand-editing past the window).
 6. **Merge to `main`** — CI (`.github/workflows/ci.yml`) must be green.
-7. **GitHub Actions release job** — on push to `main`, `release.yml` builds,
-   publishes to PyPI (Trusted Publishing), and creates the `vX.Y.Z` GitHub
-   Release when that version is new.
+7. **GitHub Actions release job** — after CI succeeds on `main`, `release.yml`
+   builds, publishes to PyPI (Trusted Publishing), and creates the `vX.Y.Z`
+   GitHub Release when that version is new. Docs-only commits skip the release
+   toolchain once the existing version is detected.
 8. **PyPI verification** — `pip index versions openextract` / the PyPI project
    page shows the new version; a clean venv install imports.
 9. **GitHub Release verification** — tag `vX.Y.Z` exists with release notes.

--- a/scripts/ci_needed.py
+++ b/scripts/ci_needed.py
@@ -1,0 +1,83 @@
+"""Decide which CI jobs a change set must run."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+
+ALWAYS_ALL = frozenset(
+    {
+        ".github/workflows/ci.yml",
+        "pyproject.toml",
+        "uv.lock",
+        ".python-version",
+        "scripts/ci_needed.py",
+    }
+)
+JOB_PREFIXES: dict[str, tuple[str, ...]] = {
+    "lint": ("src/", "tests/", "examples/", "scripts/", "docs/api-reference.md"),
+    "test": ("src/", "tests/", "examples/"),
+    "package": ("src/",),
+}
+
+
+def jobs_for_paths(changed: Sequence[str]) -> dict[str, bool]:
+    """Return which CI jobs to run for ``changed`` repository paths."""
+    if not changed:
+        return dict.fromkeys(JOB_PREFIXES, False)
+    if any(path in ALWAYS_ALL for path in changed):
+        return dict.fromkeys(JOB_PREFIXES, True)
+    return {job: _touched(changed, prefixes) for job, prefixes in JOB_PREFIXES.items()}
+
+
+def _touched(changed: Iterable[str], prefixes: tuple[str, ...]) -> bool:
+    return any(path == prefix or path.startswith(prefix) for path in changed for prefix in prefixes)
+
+
+def _write_outputs(path: Path, jobs: Mapping[str, bool]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        for name, enabled in jobs.items():
+            handle.write(f"{name}={'true' if enabled else 'false'}\n")
+
+
+def _changed_files(base: str, head: str) -> list[str] | None:
+    try:
+        return subprocess.check_output(
+            ["git", "diff", "--name-only", "--diff-filter=ACDMRT", base, head],
+            text=True,
+        ).splitlines()
+    except subprocess.CalledProcessError as exc:
+        print(f"git diff failed ({exc}); running all jobs")
+        return None
+
+
+def main() -> int:
+    output = Path(os.environ["GITHUB_OUTPUT"])
+    event = os.environ.get("EVENT_NAME", "")
+    base = os.environ.get("BASE_SHA", "")
+    head = os.environ.get("HEAD_SHA", "")
+
+    if event == "workflow_dispatch" or not base or set(base) == {"0"}:
+        print("Running all jobs (manual dispatch or no comparison base)")
+        _write_outputs(output, dict.fromkeys(JOB_PREFIXES, True))
+        return 0
+
+    changed = _changed_files(base, head)
+    if changed is None:
+        _write_outputs(output, dict.fromkeys(JOB_PREFIXES, True))
+        return 0
+
+    print("Changed files:")
+    for path in changed:
+        print(f"  {path}")
+    jobs = jobs_for_paths(changed)
+    print("jobs: " + " ".join(f"{name}={value}" for name, value in jobs.items()))
+    _write_outputs(output, jobs)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_needed.py
+++ b/scripts/ci_needed.py
@@ -20,8 +20,9 @@ ALWAYS_ALL = frozenset(
 JOB_PREFIXES: dict[str, tuple[str, ...]] = {
     "lint": ("src/", "tests/", "examples/", "scripts/", "docs/api-reference.md"),
     "test": ("src/", "tests/", "examples/"),
-    "package": ("src/",),
+    "package": ("src/", "README.md", "LICENSE"),
 }
+PATH_FILTERED_EVENTS = frozenset({"pull_request", "merge_group"})
 
 
 def jobs_for_paths(changed: Sequence[str]) -> dict[str, bool]:
@@ -46,12 +47,18 @@ def _write_outputs(path: Path, jobs: Mapping[str, bool]) -> None:
 def _changed_files(base: str, head: str) -> list[str] | None:
     try:
         return subprocess.check_output(
-            ["git", "diff", "--name-only", "--diff-filter=ACDMRT", base, head],
+            ["git", "diff", "--name-only", "--no-renames", "--diff-filter=ACDMRT", base, head],
             text=True,
         ).splitlines()
     except subprocess.CalledProcessError as exc:
-        print(f"git diff failed ({exc}); running all jobs")
+        print(f"git diff failed: {exc}")
         return None
+
+
+def _run_all_jobs(output: Path, reason: str) -> int:
+    print(f"Running all jobs ({reason})")
+    _write_outputs(output, dict.fromkeys(JOB_PREFIXES, True))
+    return 0
 
 
 def main() -> int:
@@ -60,15 +67,14 @@ def main() -> int:
     base = os.environ.get("BASE_SHA", "")
     head = os.environ.get("HEAD_SHA", "")
 
-    if event == "workflow_dispatch" or not base or set(base) == {"0"}:
-        print("Running all jobs (manual dispatch or no comparison base)")
-        _write_outputs(output, dict.fromkeys(JOB_PREFIXES, True))
-        return 0
+    if event not in PATH_FILTERED_EVENTS:
+        return _run_all_jobs(output, f"event {event!r} is not path-filtered")
+    if not base or set(base) == {"0"}:
+        return _run_all_jobs(output, "no comparison base")
 
     changed = _changed_files(base, head)
     if changed is None:
-        _write_outputs(output, dict.fromkeys(JOB_PREFIXES, True))
-        return 0
+        return _run_all_jobs(output, "git diff failed")
 
     print("Changed files:")
     for path in changed:

--- a/tests/test_ci_needed.py
+++ b/tests/test_ci_needed.py
@@ -1,15 +1,45 @@
 """Path-filter decisions for CI jobs."""
 
 import runpy
+import subprocess
 from pathlib import Path
 
-jobs_for_paths = runpy.run_path(
-    str(Path(__file__).resolve().parents[1] / "scripts" / "ci_needed.py")
-)["jobs_for_paths"]
+_MODULE = runpy.run_path(str(Path(__file__).resolve().parents[1] / "scripts" / "ci_needed.py"))
+jobs_for_paths = _MODULE["jobs_for_paths"]
+ci_needed_main = _MODULE["main"]
+
+ALL_JOBS_OUTPUT = ["lint=true", "test=true", "package=true"]
+
+
+def _run_main(monkeypatch, tmp_path, *, event, base="", head=""):
+    output = tmp_path / "github_output"
+    monkeypatch.setenv("GITHUB_OUTPUT", str(output))
+    monkeypatch.setenv("EVENT_NAME", event)
+    monkeypatch.setenv("BASE_SHA", base)
+    monkeypatch.setenv("HEAD_SHA", head)
+    assert ci_needed_main() == 0
+    return output.read_text(encoding="utf-8").splitlines()
+
+
+def _git(repo, *args):
+    return subprocess.check_output(
+        [
+            "git",
+            "-c",
+            "user.email=ci@example.com",
+            "-c",
+            "user.name=CI",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        cwd=repo,
+        text=True,
+    ).strip()
 
 
 def test_docs_only_skips_python_jobs():
-    assert jobs_for_paths(["docs/cli.md", "README.md"]) == {
+    assert jobs_for_paths(["docs/cli.md", "docs/guide.md"]) == {
         "lint": False,
         "test": False,
         "package": False,
@@ -78,3 +108,51 @@ def test_ci_workflow_change_runs_all_jobs():
         "test": True,
         "package": True,
     }
+
+
+def test_readme_runs_package_job():
+    assert jobs_for_paths(["README.md"]) == {
+        "lint": False,
+        "test": False,
+        "package": True,
+    }
+
+
+def test_license_runs_package_job():
+    assert jobs_for_paths(["LICENSE"]) == {
+        "lint": False,
+        "test": False,
+        "package": True,
+    }
+
+
+def test_push_event_runs_all_jobs(monkeypatch, tmp_path):
+    """Pushes to main gate releases, so their runs must never be path-filtered."""
+    lines = _run_main(monkeypatch, tmp_path, event="push", base="a" * 40, head="b" * 40)
+    assert lines == ALL_JOBS_OUTPUT
+
+
+def test_workflow_dispatch_runs_all_jobs(monkeypatch, tmp_path):
+    assert _run_main(monkeypatch, tmp_path, event="workflow_dispatch") == ALL_JOBS_OUTPUT
+
+
+def test_pull_request_without_base_runs_all_jobs(monkeypatch, tmp_path):
+    assert _run_main(monkeypatch, tmp_path, event="pull_request", base="0" * 40) == ALL_JOBS_OUTPUT
+
+
+def test_pull_request_rename_out_of_src_runs_package(monkeypatch, tmp_path):
+    """A file moved out of src/ must still count as a package change (no rename coalescing)."""
+    repo = tmp_path / "repo"
+    (repo / "src").mkdir(parents=True)
+    _git(repo, "init")
+    (repo / "src" / "module.py").write_text("VALUE = 1\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "add module")
+    base = _git(repo, "rev-parse", "HEAD")
+    _git(repo, "mv", "src/module.py", "module.py")
+    _git(repo, "commit", "-m", "move module out of src")
+    head = _git(repo, "rev-parse", "HEAD")
+
+    monkeypatch.chdir(repo)
+    lines = _run_main(monkeypatch, tmp_path, event="pull_request", base=base, head=head)
+    assert "package=true" in lines

--- a/tests/test_ci_needed.py
+++ b/tests/test_ci_needed.py
@@ -1,0 +1,80 @@
+"""Path-filter decisions for CI jobs."""
+
+import runpy
+from pathlib import Path
+
+jobs_for_paths = runpy.run_path(
+    str(Path(__file__).resolve().parents[1] / "scripts" / "ci_needed.py")
+)["jobs_for_paths"]
+
+
+def test_docs_only_skips_python_jobs():
+    assert jobs_for_paths(["docs/cli.md", "README.md"]) == {
+        "lint": False,
+        "test": False,
+        "package": False,
+    }
+
+
+def test_src_change_runs_all_jobs():
+    assert jobs_for_paths(["src/openextract/_extract.py"]) == {
+        "lint": True,
+        "test": True,
+        "package": True,
+    }
+
+
+def test_tests_skip_package_smoke():
+    assert jobs_for_paths(["tests/test_cli.py"]) == {
+        "lint": True,
+        "test": True,
+        "package": False,
+    }
+
+
+def test_api_reference_runs_lint_only():
+    assert jobs_for_paths(["docs/api-reference.md"]) == {
+        "lint": True,
+        "test": False,
+        "package": False,
+    }
+
+
+def test_lockfile_runs_all_jobs():
+    assert jobs_for_paths(["uv.lock"]) == {
+        "lint": True,
+        "test": True,
+        "package": True,
+    }
+
+
+def test_examples_run_lint_and_tests():
+    assert jobs_for_paths(["examples/basic/local_file.py"]) == {
+        "lint": True,
+        "test": True,
+        "package": False,
+    }
+
+
+def test_scripts_run_lint_only():
+    assert jobs_for_paths(["scripts/bench.py"]) == {
+        "lint": True,
+        "test": False,
+        "package": False,
+    }
+
+
+def test_empty_change_set_skips_all_jobs():
+    assert jobs_for_paths([]) == {
+        "lint": False,
+        "test": False,
+        "package": False,
+    }
+
+
+def test_ci_workflow_change_runs_all_jobs():
+    assert jobs_for_paths([".github/workflows/ci.yml"]) == {
+        "lint": True,
+        "test": True,
+        "package": True,
+    }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Speed up CI by running only the jobs a change can affect, canceling stale pull-request runs, and publishing a release only after CI is green on `main`.

## Changes

- Path-filter lint, tests, and package smoke tests so docs-only PRs skip Python setup
- Cancel in-progress pull-request CI when a new commit is pushed
- Cache uv downloads and skip environment resync after `uv sync --frozen`
- Collect 100% coverage on Python 3.12 only; still run the 3.13 test matrix
- Gate PyPI/GitHub releases on a successful CI run for `main`, and skip uv/build when the version already exists
- Deploy GitHub Pages only when `docs/` (or the deploy workflow) changes
- Keep a single `CI` aggregator job so required checks stay green when jobs are skipped

## Testing

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest -v --cov=openextract --cov-report=term-missing`
- `uv run coverage report --fail-under=100`

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff95b-4c45-78c4-a411-38baf725895a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff95b-4c45-78c4-a411-38baf725895a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



## Follow-up

The `CI` aggregator job only protects `main` once branch protection requires the `CI` status check, and the `merge_group` trigger stays inert until a merge queue is enabled; neither is configured today. After merge, update branch protection to require the `CI` check.
