### PR TITLE
Add direct, search, and code extraction styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ timing when that is known.
 ## [Unreleased]
 
 ### Added
+- Extraction styles: `style='direct'` (default) still sends media to the model
+  in one shot; `style='search'` uses Pydantic AI Harness `FileSystem` tools
+  (read, regex search, glob) on text documents; `style='code'` uses Harness
+  `CodeMode` so the model can write Python against a workspace copy of the
+  text. Available on every extract API, reusable sessions, and as `--style`
+  on the CLI. Install `pydantic-ai-harness` for search and
+  `pydantic-ai-harness[codemode]` for code execution.
 - Typed input and result contracts: `ExtractionInput` supports direct
   `os.PathLike` sources with per-item `media_type` and an optional safe
   `name`, and `ExtractionResult[T]` carries output, usage, attempts, timing,

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 
 - **Type-safe output.** Define your shape with Pydantic; get back a validated instance.
 - **One function, many modalities.** Documents (PDF, DOCX), images, audio, and video.
+- **Extraction styles.** Pass the document directly, search it with file tools, or write Python against the text via [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/).
 - **Local files or URLs.** Pass a path or an `https://` URL &mdash; `openextract` handles fetching.
 - **Bring your own model.** OpenAI, Anthropic, Google, AWS Bedrock, xAI, Cohere, Hugging Face, Groq, Cerebras, Mistral, and Ollama supported out of the box via [`pydantic-ai`](https://github.com/pydantic/pydantic-ai).
 - **Explicit error handling.** Distinct exceptions for URL fetch, schema validation, and model errors.
@@ -41,7 +42,7 @@ Or with pip:
 pip install openextract
 ```
 
-Model calls require a provider SDK. Install the extra for the provider you use, for example `openextract[openai]`, `openextract[anthropic]`, or `openextract[all]` for every supported provider. The base package ships `pydantic-ai-slim` without provider SDKs pre-installed. If the requested provider SDK is missing, `openextract` raises `ProviderNotInstalledError` with a provider-specific `pip install 'openextract[...]'` command when the model prefix is known.
+Model calls require a provider SDK. Install the extra for the provider you use, for example `openextract[openai]`, `openextract[anthropic]`, or `openextract[all]` for every supported provider. Agentic `search` and `code` styles need [`pydantic-ai-harness`](https://pydantic.dev/docs/ai/harness/) (`pip install pydantic-ai-harness` / `pip install 'pydantic-ai-harness[codemode]'`). The base package ships `pydantic-ai-slim` without provider SDKs pre-installed. If the requested provider SDK is missing, `openextract` raises `ProviderNotInstalledError` with a provider-specific `pip install 'openextract[...]'` command when the model prefix is known.
 
 Requires Python 3.12+.
 
@@ -69,6 +70,41 @@ print(result.language)
 ```
 
 `result` is a fully-validated `PdfInfo` instance &mdash; not a dict, not a string.
+
+## Extraction styles
+
+`style` selects how the model inspects the input. The default, `direct`, is the
+current behavior: the resolved media is passed to the LLM in one shot. For
+**text** documents you can instead use agentic search or code execution, both
+powered by [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/).
+
+```python
+from openextract import extract, ExtractionStyle
+
+# Default: send the document bytes to the model.
+extract(schema=PdfInfo, model="openai:gpt-5", input_file="notes.txt")
+
+# Grep/read the text with sandboxed file tools (needs pydantic-ai-harness).
+extract(
+    schema=PdfInfo,
+    model="openai:gpt-5",
+    input_file="notes.txt",
+    style="search",  # or ExtractionStyle.SEARCH
+)
+
+# Write Python against a workspace copy of the document (needs pydantic-ai-harness[codemode]).
+extract(
+    schema=PdfInfo,
+    model="openai:gpt-5",
+    input_file="notes.txt",
+    style="code",
+)
+```
+
+`search` and `code` require UTF-8 text (`text/*`, JSON, XML, YAML, and similar).
+PDFs, images, audio, and video stay on `direct`. Missing packages raise
+`ProviderNotInstalledError` with a `pip install pydantic-ai-harness` or
+`pip install 'pydantic-ai-harness[codemode]'` hint. The CLI flag is `--style`.
 
 ## Reusable sessions
 
@@ -339,6 +375,9 @@ cat ./reports/q4.pdf | openextract - \
 - `--schema` is a Python import path of the form `module:ClassName` resolving to a Pydantic model.
 - `--model` is a `pydantic-ai` model identifier.
 - `--instructions` is optional natural-language guidance.
+- `--style` is `direct` (default), `search` (file tools on text), or `code`
+  (write Python against text). `search` needs `pydantic-ai-harness`; `code`
+  needs `pydantic-ai-harness[codemode]`.
 - `--media-type` sets MIME type for stdin or overrides guessing for paths/URLs.
 - `--usage` prints a JSON object with `result` and `usage` (single input only).
 - `--output` is `json` (default) or `repr`.
@@ -425,7 +464,8 @@ the compatibility notes below even though it is not exported from `__all__`.
 
 | API | Status for 1.0 | Notes |
 | --- | --- | --- |
-| `extract` | Stable | Primary synchronous API. Signature, return type, media input forms (`str`, `os.PathLike`, `bytes`, file-like, `ExtractionInput`), retry behavior, and public exception categories are intended to carry into 1.0 unchanged. |
+| `ExtractionStyle` | Provisional | `direct`, `search`, or `code` extraction strategy. `search`/`code` are text-only and require `pydantic-ai-harness`. |
+| `extract` | Stable | Primary synchronous API. Signature, return type, media input forms (`str`, `os.PathLike`, `bytes`, file-like, `ExtractionInput`), retry behavior, and public exception categories are intended to carry into 1.0 unchanged. `style` is additive. |
 | `extract_async` | Stable | Async sibling of `extract`; same input contract and retry behavior, with `Agent.run` instead of `run_sync`. |
 | `extract_with_usage` | Stable | Usage-returning sync API. The `(output, Usage)` tuple shape is stable; exact token values depend on provider reporting. |
 | `extract_with_usage_async` | Stable | Async sibling of `extract_with_usage`; same tuple shape and retry behavior. |

--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ extract(
 ```
 
 `search` and `code` require UTF-8 text (`text/*`, JSON, XML, YAML, and similar).
-PDFs, images, audio, and video stay on `direct`. Missing packages raise
-`ProviderNotInstalledError` with a `pip install pydantic-ai-harness` or
-`pip install 'pydantic-ai-harness[codemode]'` hint. The CLI flag is `--style`.
+PDFs, Office documents, images, audio, and video stay on `direct`. Missing
+packages raise `ProviderNotInstalledError` with a `pip install pydantic-ai-harness`
+or `pip install 'pydantic-ai-harness[codemode]'` hint. The integration was
+written against `pydantic-ai-harness` 0.18.x. The CLI flag is `--style`.
 
 ## Reusable sessions
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -14,13 +14,15 @@ in the same change as any public signature.
 ### `Extractor(schema, model=None, instructions=None, *, style='direct', agent=None, model_settings=None, timeout=None, instrument=False, retry_policy=None, max_input_bytes=None, url_timeout=None)`
 
 Reusable synchronous extraction session. Enter it with `with`; then call
-`extract(input_file, *, style='direct', media_type=None)` or
-`extract_with_usage(input_file, *, style='direct', media_type=None)`. The agent, model provider
+`extract(input_file, *, media_type=None)` or
+`extract_with_usage(input_file, *, media_type=None)`. The agent, model provider
 client, and URL-fetch client are constructed once and closed on context exit.
 
 `model` accepts either a known model string or a configured
 `pydantic_ai.models.Model`. `style` selects how the model inspects the input
-(`direct`, `search`, or `code`; see [Common arguments](#common-arguments)).
+(`direct`, `search`, or `code`; see [Common arguments](#common-arguments)) and
+applies to every call in the session; `search` and `code` sessions build their
+harness agent and temporary workspace once on enter and remove both on exit.
 As an advanced alternative, `agent` accepts a fully
 configured Pydantic AI `Agent`; it is mutually exclusive with `model`, and its
 output is revalidated against `schema`. Non-`direct` styles cannot be combined

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -11,19 +11,22 @@ in the same change as any public signature.
 
 ## Extraction
 
-### `Extractor(schema, model=None, instructions=None, *, agent=None, model_settings=None, timeout=None, instrument=False, retry_policy=None, max_input_bytes=None, url_timeout=None)`
+### `Extractor(schema, model=None, instructions=None, *, style='direct', agent=None, model_settings=None, timeout=None, instrument=False, retry_policy=None, max_input_bytes=None, url_timeout=None)`
 
 Reusable synchronous extraction session. Enter it with `with`; then call
-`extract(input_file, *, media_type=None)` or
-`extract_with_usage(input_file, *, media_type=None)`. The agent, model provider
+`extract(input_file, *, style='direct', media_type=None)` or
+`extract_with_usage(input_file, *, style='direct', media_type=None)`. The agent, model provider
 client, and URL-fetch client are constructed once and closed on context exit.
 
 `model` accepts either a known model string or a configured
-`pydantic_ai.models.Model`. As an advanced alternative, `agent` accepts a fully
+`pydantic_ai.models.Model`. `style` selects how the model inspects the input
+(`direct`, `search`, or `code`; see [Common arguments](#common-arguments)).
+As an advanced alternative, `agent` accepts a fully
 configured Pydantic AI `Agent`; it is mutually exclusive with `model`, and its
-output is revalidated against `schema`.
+output is revalidated against `schema`. Non-`direct` styles cannot be combined
+with an injected `agent`.
 
-### `AsyncExtractor(schema, model=None, instructions=None, *, agent=None, model_settings=None, timeout=None, instrument=False, retry_policy=None, max_input_bytes=None, url_timeout=None)`
+### `AsyncExtractor(schema, model=None, instructions=None, *, style='direct', agent=None, model_settings=None, timeout=None, instrument=False, retry_policy=None, max_input_bytes=None, url_timeout=None)`
 
 Async session counterpart. Enter it with `async with`; then await `extract` or
 `extract_with_usage`. It shares one async HTTP client and one agent across
@@ -36,37 +39,37 @@ Frozen session retry configuration. Only transient `ModelError` failures are
 retried. The backoff and bounded provider `Retry-After` behavior match the
 one-shot function arguments.
 
-### `extract(schema, model, input_file, instructions=None, *, media_type=None, max_input_bytes=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
+### `extract(schema, model, input_file, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Extract one input synchronously and return an instance of `schema`.
 
-### `extract_async(schema, model, input_file, instructions=None, *, media_type=None, max_input_bytes=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
+### `extract_async(schema, model, input_file, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Async counterpart to `extract`. It uses `Agent.run` and returns an instance of
 `schema`.
 
-### `extract_with_usage(schema, model, input_file, instructions=None, *, media_type=None, max_input_bytes=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
+### `extract_with_usage(schema, model, input_file, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Extract one input synchronously and return `(output, Usage)`. It has the same
 retry behavior as `extract`; `Usage` describes the successful model call.
 
-### `extract_with_usage_async(schema, model, input_file, instructions=None, *, media_type=None, max_input_bytes=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
+### `extract_with_usage_async(schema, model, input_file, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Async counterpart to `extract_with_usage`; returns `(output, Usage)`.
 
-### `extract_many(schema, model, input_files, instructions=None, *, media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
+### `extract_many(schema, model, input_files, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Run concurrent extractions from synchronous code. Results preserve input order.
 When `return_exceptions=True`, per-item exceptions appear in the result list.
 Do not call this function from a running event loop; use
 `extract_many_async` instead.
 
-### `extract_many_async(schema, model, input_files, instructions=None, *, media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
+### `extract_many_async(schema, model, input_files, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Async counterpart to `extract_many`; it has the same arguments, result ordering,
 and per-item retry behavior.
 
-### `iter_extract_many_async(schema, model, input_files, instructions=None, *, media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
+### `iter_extract_many_async(schema, model, input_files, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Return an async iterator of `(input_index, result)` pairs in completion order.
 Inputs are consumed lazily, at most `max_concurrency` items are scheduled, and
@@ -77,7 +80,7 @@ With `return_exceptions=False`, the first failure cancels and awaits outstanding
 work before being raised. With `return_exceptions=True`, item exceptions are
 yielded in the result position and streaming continues.
 
-### `extract_many_with_results(schema, model, input_files, instructions=None, *, media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
+### `extract_many_with_results(schema, model, input_files, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Run a batch and return per-item [`ExtractionResult`](#extractionresult) objects
 instead of bare schema instances. It has the same arguments, input ordering,
@@ -87,7 +90,7 @@ source label. With `return_exceptions=True`, failed items appear as
 `Exception` values in place. Use [`total_usage`](#total_usageresults) to
 aggregate token usage across the returned results.
 
-### `extract_many_with_results_async(schema, model, input_files, instructions=None, *, media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
+### `extract_many_with_results_async(schema, model, input_files, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Async counterpart to `extract_many_with_results`; it has the same arguments,
 result ordering, and per-item retry behavior.
@@ -141,6 +144,7 @@ internals; `source` is sanitized.
 | `model` | `str \| Model` | `pydantic-ai` model identifier or configured model instance. |
 | `input_file` | `str \| os.PathLike[str] \| bytes \| BinaryIO \| ExtractionInput` | Local path, HTTP(S) URL, `Path`, bytes, binary file-like object, or `ExtractionInput`. |
 | `instructions` | `str \| None` | Optional model guidance. |
+| `style` | `ExtractionStyle \| str` | How the model inspects the input. `direct` (default) sends media in one shot. `search` gives the model sandboxed file tools (read/grep) against a text document. `code` lets the model write Python against a text document via [Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/). `search` needs `pydantic-ai-harness`; `code` needs `pydantic-ai-harness[codemode]`. |
 | `media_type` | `str \| None` | Required for bytes and file-like inputs without a per-item type; overrides inference for paths and URLs. Item-level `ExtractionInput.media_type` wins in batch calls. |
 | `max_input_bytes` | `int \| None` | Per-input byte cap; `None` uses `OPENEXTRACT_MAX_INPUT_BYTES` or the 50 MiB default. |
 | `max_retries` | `int` | Extra attempts after transient `ModelError`; defaults to `0`. |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -145,6 +145,15 @@ flag, the CLI uses `OPENEXTRACT_MAX_INPUT_BYTES` or the 50 MiB default. Values
 must be positive integers. Oversized inputs fail before a model call and exit
 `5`; URL bodies and stdin remain bounded even without a reliable length header.
 
+## Extraction styles
+
+`--style direct` (default) sends the resolved media to the model in one shot.
+`--style search` and `--style code` are text-only: search gives the model
+sandboxed file tools (read, regex search, glob), and code lets it write Python
+against a workspace copy of the document via Pydantic AI Harness. Missing extras
+exit `6` (`ProviderNotInstalledError`). Non-text inputs raise `ValueError`
+(exit `1`).
+
 ## Related docs
 
 - [Troubleshooting](troubleshooting.md)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,7 +33,10 @@ pip install 'openextract[all]'
 ```
 
 `style='search'` needs `pydantic-ai-harness`; `style='code'` needs
-`pydantic-ai-harness[codemode]`.
+`pydantic-ai-harness[codemode]`. The styles integration was written against
+`pydantic-ai-harness` 0.18.x, which requires `pydantic-ai-slim` 2.x; the
+repository's locked development environment cannot resolve it, so CI does not
+exercise the live harness integration.
 
 ## Missing provider credentials
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -32,6 +32,9 @@ pip install 'openextract[xai]'
 pip install 'openextract[all]'
 ```
 
+`style='search'` needs `pydantic-ai-harness`; `style='code'` needs
+`pydantic-ai-harness[codemode]`.
+
 ## Missing provider credentials
 
 **Symptoms**

--- a/examples/README.md
+++ b/examples/README.md
@@ -50,6 +50,7 @@ uv run python -m examples.run_all
 | `advanced/` | `extract_with_usage.py` | xAI | `extract_with_usage()` and token counts |
 | `advanced/` | `retry_extract.py` | OpenAI | `max_retries` / `retry_backoff` |
 | `advanced/` | `reusable_sessions.py` | TestModel | Sync/async sessions and dependency-injected agents |
+| `advanced/` | `extraction_styles.py` | TestModel | `style='direct'` vs `search` / `code` |
 | `advanced/` | `error_handling.py` | — | Catching `UrlFetchError` (no model call) |
 | `audio/` | `meeting_notes.py` | xAI | Audio → structured meeting notes (bring your own file) |
 | `cli/` | `schemas.py` | — | Pydantic models for CLI `--schema` |

--- a/examples/advanced/extraction_styles.py
+++ b/examples/advanced/extraction_styles.py
@@ -1,0 +1,38 @@
+"""Choose how the model inspects a text document.
+
+``direct`` sends the bytes to the LLM. ``search`` and ``code`` use the
+Pydantic AI harness (file tools or sandboxed Python) and need
+``pydantic-ai-harness`` / ``pydantic-ai-harness[codemode]``.
+"""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+from openextract import ExtractionStyle, Extractor
+
+
+class Note(BaseModel):
+    title: str
+    topic: str
+
+
+def test_agent() -> Agent:
+    return Agent(
+        TestModel(custom_output_args={"title": "Q4 notes", "topic": "revenue"}),
+        output_type=Note,
+    )
+
+
+def main() -> None:
+    document = b"Q4 notes: revenue grew 12% year over year."
+    with Extractor(Note, agent=test_agent(), style=ExtractionStyle.DIRECT) as extractor:
+        result = extractor.extract(document, media_type="text/plain")
+    print(result.model_dump_json(indent=2))
+    print("Other styles: style='search' (grep/read) or style='code' (write Python).")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -31,6 +31,7 @@ API_EXAMPLES: list[tuple[str, list[str]]] = [
 NO_API_EXAMPLES: list[str] = [
     "examples.advanced.error_handling",
     "examples.advanced.reusable_sessions",
+    "examples.advanced.extraction_styles",
 ]
 
 

--- a/src/openextract/__init__.py
+++ b/src/openextract/__init__.py
@@ -20,6 +20,7 @@ from ._extract import (
     iter_extract_many_async,
     total_usage,
 )
+from ._styles import ExtractionStyle
 from .exceptions import (
     ExtractionError,
     InputTooLargeError,
@@ -35,6 +36,7 @@ __all__ = [
     "RetryPolicy",
     "ExtractionInput",
     "ExtractionResult",
+    "ExtractionStyle",
     "extract",
     "extract_async",
     "extract_many",

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -13,6 +13,7 @@ from dotenv import load_dotenv
 from pydantic import BaseModel
 
 from ._extract import extract, extract_many, extract_with_usage
+from ._styles import ExtractionStyle
 from .exceptions import (
     ExtractionError,
     ModelError,
@@ -132,6 +133,15 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Optional natural-language instructions for the model.",
     )
     parser.add_argument(
+        "--style",
+        choices=tuple(item.value for item in ExtractionStyle),
+        default=ExtractionStyle.DIRECT.value,
+        help=(
+            "Extraction style: 'direct' (default) sends media to the model; "
+            "'search' uses file tools on text; 'code' writes Python against text."
+        ),
+    )
+    parser.add_argument(
         "--media-type",
         default=None,
         metavar="MIME",
@@ -223,6 +233,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     model=args.model,
                     input_file=input_file,
                     instructions=args.instructions,
+                    style=args.style,
                     media_type=media_type,
                     max_input_bytes=args.max_input_bytes,
                     max_retries=args.max_retries,
@@ -236,6 +247,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                     model=args.model,
                     input_file=input_file,
                     instructions=args.instructions,
+                    style=args.style,
                     media_type=media_type,
                     max_input_bytes=args.max_input_bytes,
                     max_retries=args.max_retries,
@@ -248,6 +260,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 model=args.model,
                 input_files=input_files,
                 instructions=args.instructions,
+                style=args.style,
                 media_type=media_type,
                 max_input_bytes=args.max_input_bytes,
                 max_retries=args.max_retries,

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -8,7 +8,9 @@ import math
 import mimetypes
 import os
 import random
+import shutil
 import socket
+import tempfile
 import threading
 import time
 from collections.abc import (
@@ -44,7 +46,14 @@ else:
         return PydanticAgent(*args, **kwargs)
 
 
-from ._styles import ExtractionStyle, normalize_style, prepared_style_run
+from ._styles import (
+    ExtractionStyle,
+    materialize_text_document,
+    normalize_style,
+    prepared_style_run,
+    style_capabilities,
+    style_run_inputs,
+)
 from .exceptions import (
     ExtractionError,
     InputTooLargeError,
@@ -1355,6 +1364,8 @@ class _ExtractorSession[T: BaseModel]:
         )
         self._entered = False
         self._closed = False
+        self._style_workspace: tempfile.TemporaryDirectory[str] | None = None
+        self._style_run_index = 0
 
     def _validate_output(self, output: object) -> T:
         with _extraction_errors():
@@ -1370,19 +1381,65 @@ class _ExtractorSession[T: BaseModel]:
         if not self._entered:
             raise RuntimeError(f"{class_name} must be used as a context manager before extraction.")
 
-    def _agent_for_run(self, extra_capabilities: Sequence[object]) -> PydanticAgent:
-        if not extra_capabilities:
-            assert self._agent is not None
-            return self._agent
+    def _enter_style_workspace(self) -> None:
+        """Create the session workspace and its agent for search/code styles.
+
+        The agent (and its provider HTTP client) is built once per session and
+        lives until the session closes, matching the direct-style lifecycle.
+        """
+        if self._style is ExtractionStyle.DIRECT:
+            return
         assert self._model is not None
-        return _build_agent(
-            self._schema,
-            self._model,
-            self._instructions,
-            model_settings=self._model_settings,
-            instrument=self._instrument,
-            extra_capabilities=extra_capabilities,
-        )
+        self._style_workspace = tempfile.TemporaryDirectory(prefix="openextract-")
+        with _extraction_errors():
+            self._agent = _build_agent(
+                self._schema,
+                self._model,
+                self._instructions,
+                model_settings=self._model_settings,
+                instrument=self._instrument,
+                extra_capabilities=style_capabilities(
+                    self._style, Path(self._style_workspace.name)
+                ),
+            )
+
+    def _discard_style_state(self) -> None:
+        """Drop the style agent and remove the workspace owned by the session."""
+        if self._style_workspace is not None:
+            self._style_workspace.cleanup()
+            self._style_workspace = None
+            self._agent = None
+
+    @contextmanager
+    def _style_document(self, file_bytes: bytes, file_type: str) -> Iterator[list]:
+        """Materialize one document in the session workspace for a single call.
+
+        Each call gets its own subdirectory so concurrent async extractions
+        never collide. The subdirectory is removed when the call finishes; the
+        workspace itself lives until the session closes, so documents persist
+        across retries within a call.
+        """
+        assert self._style_workspace is not None
+        self._style_run_index += 1
+        run_dir = Path(self._style_workspace.name) / f"run{self._style_run_index}"
+        run_dir.mkdir()
+        try:
+            filename = materialize_text_document(run_dir, file_bytes, file_type, style=self._style)
+            yield style_run_inputs(self._style, f"{run_dir.name}/{filename}")
+        finally:
+            shutil.rmtree(run_dir, ignore_errors=True)
+
+    @contextmanager
+    def _session_agent_inputs(
+        self, file_bytes: bytes, file_type: str
+    ) -> Iterator[tuple[PydanticAgent, list]]:
+        """Pair the session agent with per-call run inputs for one extraction."""
+        assert self._agent is not None
+        if self._style is ExtractionStyle.DIRECT:
+            yield self._agent, _build_run_inputs(file_bytes, file_type)
+            return
+        with self._style_document(file_bytes, file_type) as inputs:
+            yield self._agent, inputs
 
 
 class Extractor(_ExtractorSession[T]):
@@ -1390,7 +1447,8 @@ class Extractor(_ExtractorSession[T]):
 
     An ``Extractor`` is bound to the thread that enters it and is not
     thread-safe. Use one session per thread and close it deterministically with
-    a ``with`` block.
+    a ``with`` block. ``search``/``code`` sessions build one harness agent and
+    temporary workspace on enter and remove both on close.
     """
 
     def __init__(
@@ -1442,9 +1500,11 @@ class Extractor(_ExtractorSession[T]):
         runner = asyncio.Runner(loop_factory=asyncio.new_event_loop)
         runner.__enter__()
         try:
-            if self._agent is not None:
-                runner.run(self._agent.__aenter__())
+            self._enter_style_workspace()
+            assert self._agent is not None
+            runner.run(self._agent.__aenter__())
         except BaseException:
+            self._discard_style_state()
             client.close()
             runner.close()
             raise
@@ -1466,13 +1526,14 @@ class Extractor(_ExtractorSession[T]):
             raise RuntimeError("Extractor can only be closed from the thread that entered it.")
         assert self._runner is not None
         assert self._client is not None
+        assert self._agent is not None
         suppressed = False
         try:
-            if self._agent is not None:
-                suppressed = bool(self._runner.run(self._agent.__aexit__(*exc_info)))
+            suppressed = bool(self._runner.run(self._agent.__aexit__(*exc_info)))
         finally:
             self._client.close()
             self._runner.close()
+            self._discard_style_state()
             self._entered = False
             self._closed = True
             self._client = None
@@ -1494,13 +1555,13 @@ class Extractor(_ExtractorSession[T]):
         assert self._runner is not None
         return self._runner.run(_run_extraction_async(agent, inputs))
 
-    def extract(
+    @contextmanager
+    def _prepare_session_extraction(
         self,
         input_file: ExtractionInputLike,
-        *,
-        media_type: str | None = None,
-    ) -> T:
-        """Extract one input using the session's reusable agent and clients."""
+        media_type: str | None,
+    ) -> Iterator[tuple[PydanticAgent, list]]:
+        """Resolve media and yield ``(agent, inputs)`` for one session call."""
         client = self._ensure_sync_open()
         with _extraction_errors():
             file_bytes, file_type = _get_media(
@@ -1509,21 +1570,27 @@ class Extractor(_ExtractorSession[T]):
                 max_input_bytes=self._max_input_bytes,
                 client=client,
             )
-        with prepared_style_run(self._style, file_bytes, file_type) as (
-            capabilities,
-            style_inputs,
-        ):
-            inputs = _resolve_run_inputs(file_bytes, file_type, style_inputs)
-            agent = self._agent_for_run(capabilities)
+        with self._session_agent_inputs(file_bytes, file_type) as prepared:
+            yield prepared
 
-            def _once() -> T:
-                return self._validate_output(self._run_agent(agent, inputs).output)
+    def _run_session_retries[R](self, fn: Callable[[], R]) -> R:
+        return _run_with_retries_sync(
+            fn,
+            max_retries=self._retry_policy.max_retries,
+            retry_backoff=self._retry_policy.backoff,
+            retry_max_backoff=self._retry_policy.max_backoff,
+        )
 
-            return _run_with_retries_sync(
-                _once,
-                max_retries=self._retry_policy.max_retries,
-                retry_backoff=self._retry_policy.backoff,
-                retry_max_backoff=self._retry_policy.max_backoff,
+    def extract(
+        self,
+        input_file: ExtractionInputLike,
+        *,
+        media_type: str | None = None,
+    ) -> T:
+        """Extract one input using the session's reusable agent and clients."""
+        with self._prepare_session_extraction(input_file, media_type) as (agent, inputs):
+            return self._run_session_retries(
+                lambda: self._validate_output(self._run_agent(agent, inputs).output)
             )
 
     def extract_with_usage(
@@ -1533,35 +1600,22 @@ class Extractor(_ExtractorSession[T]):
         media_type: str | None = None,
     ) -> tuple[T, Usage]:
         """Extract one input and return its successful-call token usage."""
-        client = self._ensure_sync_open()
-        with _extraction_errors():
-            file_bytes, file_type = _get_media(
-                input_file,
-                media_type=media_type,
-                max_input_bytes=self._max_input_bytes,
-                client=client,
-            )
-        with prepared_style_run(self._style, file_bytes, file_type) as (
-            capabilities,
-            style_inputs,
-        ):
-            inputs = _resolve_run_inputs(file_bytes, file_type, style_inputs)
-            agent = self._agent_for_run(capabilities)
+        with self._prepare_session_extraction(input_file, media_type) as (agent, inputs):
 
             def _once() -> tuple[T, Usage]:
                 result = self._run_agent(agent, inputs)
                 return self._validate_output(result.output), _usage_from_result(result)
 
-            return _run_with_retries_sync(
-                _once,
-                max_retries=self._retry_policy.max_retries,
-                retry_backoff=self._retry_policy.backoff,
-                retry_max_backoff=self._retry_policy.max_backoff,
-            )
+            return self._run_session_retries(_once)
 
 
 class AsyncExtractor(_ExtractorSession[T]):
-    """Reusable async extraction session bound to one event loop."""
+    """Reusable async extraction session bound to one event loop.
+
+    ``search``/``code`` sessions build one harness agent and temporary
+    workspace on enter and remove both on close; concurrent calls each write
+    their document into a private workspace subdirectory.
+    """
 
     def __init__(
         self,
@@ -1598,9 +1652,11 @@ class AsyncExtractor(_ExtractorSession[T]):
         self._ensure_enterable(type(self).__name__)
         client = httpx.AsyncClient(follow_redirects=False, timeout=self._url_timeout)
         try:
-            if self._agent is not None:
-                await self._agent.__aenter__()
+            self._enter_style_workspace()
+            assert self._agent is not None
+            await self._agent.__aenter__()
         except BaseException:
+            self._discard_style_state()
             await client.aclose()
             raise
         self._client = client
@@ -1620,12 +1676,13 @@ class AsyncExtractor(_ExtractorSession[T]):
                 "AsyncExtractor can only be closed from the event loop that entered it."
             )
         assert self._client is not None
+        assert self._agent is not None
         suppressed = False
         try:
-            if self._agent is not None:
-                suppressed = bool(await self._agent.__aexit__(*exc_info))
+            suppressed = bool(await self._agent.__aexit__(*exc_info))
         finally:
             await self._client.aclose()
+            self._discard_style_state()
             self._entered = False
             self._closed = True
             self._client = None
@@ -1645,13 +1702,13 @@ class AsyncExtractor(_ExtractorSession[T]):
         assert self._client is not None
         return self._client
 
-    async def extract(
+    @asynccontextmanager
+    async def _prepare_session_extraction(
         self,
         input_file: ExtractionInputLike,
-        *,
-        media_type: str | None = None,
-    ) -> T:
-        """Extract one input using the session's reusable agent and clients."""
+        media_type: str | None,
+    ) -> AsyncIterator[tuple[PydanticAgent, list]]:
+        """Resolve media and yield ``(agent, inputs)`` for one session call."""
         client = self._ensure_async_open()
         with _extraction_errors():
             file_bytes, file_type = await _get_media_async(
@@ -1660,23 +1717,31 @@ class AsyncExtractor(_ExtractorSession[T]):
                 media_type=media_type,
                 max_input_bytes=self._max_input_bytes,
             )
-        with prepared_style_run(self._style, file_bytes, file_type) as (
-            capabilities,
-            style_inputs,
-        ):
-            inputs = _resolve_run_inputs(file_bytes, file_type, style_inputs)
-            agent = self._agent_for_run(capabilities)
+        with self._session_agent_inputs(file_bytes, file_type) as prepared:
+            yield prepared
+
+    async def _run_session_retries[R](self, fn: Callable[[], Awaitable[R]]) -> R:
+        return await _run_with_retries_async(
+            fn,
+            max_retries=self._retry_policy.max_retries,
+            retry_backoff=self._retry_policy.backoff,
+            retry_max_backoff=self._retry_policy.max_backoff,
+        )
+
+    async def extract(
+        self,
+        input_file: ExtractionInputLike,
+        *,
+        media_type: str | None = None,
+    ) -> T:
+        """Extract one input using the session's reusable agent and clients."""
+        async with self._prepare_session_extraction(input_file, media_type) as (agent, inputs):
 
             async def _once() -> T:
                 result = await _run_extraction_async(agent, inputs)
                 return self._validate_output(result.output)
 
-            return await _run_with_retries_async(
-                _once,
-                max_retries=self._retry_policy.max_retries,
-                retry_backoff=self._retry_policy.backoff,
-                retry_max_backoff=self._retry_policy.max_backoff,
-            )
+            return await self._run_session_retries(_once)
 
     async def extract_with_usage(
         self,
@@ -1685,31 +1750,13 @@ class AsyncExtractor(_ExtractorSession[T]):
         media_type: str | None = None,
     ) -> tuple[T, Usage]:
         """Extract one input and return its successful-call token usage."""
-        client = self._ensure_async_open()
-        with _extraction_errors():
-            file_bytes, file_type = await _get_media_async(
-                input_file,
-                client,
-                media_type=media_type,
-                max_input_bytes=self._max_input_bytes,
-            )
-        with prepared_style_run(self._style, file_bytes, file_type) as (
-            capabilities,
-            style_inputs,
-        ):
-            inputs = _resolve_run_inputs(file_bytes, file_type, style_inputs)
-            agent = self._agent_for_run(capabilities)
+        async with self._prepare_session_extraction(input_file, media_type) as (agent, inputs):
 
             async def _once() -> tuple[T, Usage]:
                 result = await _run_extraction_async(agent, inputs)
                 return self._validate_output(result.output), _usage_from_result(result)
 
-            return await _run_with_retries_async(
-                _once,
-                max_retries=self._retry_policy.max_retries,
-                retry_backoff=self._retry_policy.backoff,
-                retry_max_backoff=self._retry_policy.max_backoff,
-            )
+            return await self._run_session_retries(_once)
 
 
 def extract(

--- a/src/openextract/_extract.py
+++ b/src/openextract/_extract.py
@@ -11,8 +11,16 @@ import random
 import socket
 import threading
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Iterable, Iterator, Mapping
-from contextlib import contextmanager
+from collections.abc import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Iterable,
+    Iterator,
+    Mapping,
+    Sequence,
+)
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from email.utils import parsedate_to_datetime
 from pathlib import Path
@@ -36,6 +44,7 @@ else:
         return PydanticAgent(*args, **kwargs)
 
 
+from ._styles import ExtractionStyle, normalize_style, prepared_style_run
 from .exceptions import (
     ExtractionError,
     InputTooLargeError,
@@ -786,6 +795,7 @@ def _build_agent(
     *,
     model_settings: ModelSettings | None = None,
     instrument: bool | InstrumentationSettings = False,
+    extra_capabilities: Sequence[object] = (),
 ) -> PydanticAgent:
     """Construct the pydantic_ai Agent, handling the ollama output-type quirk.
 
@@ -800,6 +810,7 @@ def _build_agent(
 
             output_type = NativeOutput(schema)
         capabilities, compatibility_kwargs = _instrumentation_capabilities(instrument)
+        capabilities = [*capabilities, *extra_capabilities]
         routed_model = _route_model(model) if isinstance(model, str) else model
         agent_kwargs: dict[str, object] = {
             "instructions": instructions,
@@ -1071,94 +1082,57 @@ def _model_identifier(model: str | Model, agent: object) -> str | None:
     return name if isinstance(name, str) else None
 
 
-def _prepare_run(
-    schema: type[T],
-    model: str | Model,
-    input_file: ExtractionInputLike,
-    instructions: str | None,
-    media_type: str | None,
-    max_input_bytes: int,
-) -> tuple[PydanticAgent, list]:
-    """Resolve the media payload and build the agent + run inputs."""
-    file_bytes, file_type = _get_media(
-        input_file,
-        media_type=media_type,
-        max_input_bytes=max_input_bytes,
-    )
-    agent = _build_agent(schema, model, instructions)
-    return agent, _build_run_inputs(file_bytes, file_type)
+def _resolve_run_inputs(
+    file_bytes: bytes,
+    file_type: str,
+    style_inputs: list[str] | None,
+) -> list:
+    """Use style-specific prompts when present; otherwise pass media directly."""
+    if style_inputs is None:
+        return _build_run_inputs(file_bytes, file_type)
+    return style_inputs
 
 
-async def _prepare_run_async(
-    schema: type[T],
-    model: str | Model,
-    input_file: ExtractionInputLike,
-    instructions: str | None,
-    media_type: str | None,
-    max_input_bytes: int,
-    client: httpx.AsyncClient | None = None,
-) -> tuple[PydanticAgent, list]:
-    """Async media preparation plus agent construction."""
-    file_bytes, file_type = await _get_media_async(
-        input_file,
-        client,
-        media_type=media_type,
-        max_input_bytes=max_input_bytes,
-    )
-    agent = _build_agent(schema, model, instructions)
-    return agent, _build_run_inputs(file_bytes, file_type)
-
-
+@contextmanager
 def _prepare_extraction(
-    schema: type[T],
+    schema: type[BaseModel],
     model: str | Model,
     input_file: ExtractionInputLike,
     instructions: str | None,
     media_type: str | None,
     max_input_bytes: int,
-) -> tuple[PydanticAgent, list]:
+    style: ExtractionStyle,
+) -> Iterator[tuple[PydanticAgent, list]]:
     """Prepare one extraction while applying the public exception mapping."""
     with _extraction_errors():
-        return _prepare_run(
-            schema,
-            model,
+        file_bytes, file_type = _get_media(
             input_file,
-            instructions,
-            media_type,
-            max_input_bytes,
+            media_type=media_type,
+            max_input_bytes=max_input_bytes,
         )
+    with prepared_style_run(style, file_bytes, file_type) as (capabilities, style_inputs):
+        with _extraction_errors():
+            agent = _build_agent(
+                schema,
+                model,
+                instructions,
+                extra_capabilities=capabilities,
+            )
+        yield agent, _resolve_run_inputs(file_bytes, file_type, style_inputs)
 
 
+@asynccontextmanager
 async def _prepare_extraction_async(
-    schema: type[T],
+    schema: type[BaseModel],
     model: str | Model,
     input_file: ExtractionInputLike,
     instructions: str | None,
     media_type: str | None,
     max_input_bytes: int,
+    style: ExtractionStyle,
     client: httpx.AsyncClient | None = None,
-) -> tuple[PydanticAgent, list]:
+) -> AsyncIterator[tuple[PydanticAgent, list]]:
     """Prepare one async extraction while applying public exception mapping."""
-    with _extraction_errors():
-        return await _prepare_run_async(
-            schema,
-            model,
-            input_file,
-            instructions,
-            media_type,
-            max_input_bytes,
-            client,
-        )
-
-
-async def _prepare_run_inputs_async(
-    input_file: ExtractionInputLike,
-    media_type: str | None,
-    client: httpx.AsyncClient | None = None,
-    *,
-    max_input_bytes: int,
-) -> list:
-    """Resolve one async media input and build a prompt for retry reuse."""
     with _extraction_errors():
         file_bytes, file_type = await _get_media_async(
             input_file,
@@ -1166,25 +1140,15 @@ async def _prepare_run_inputs_async(
             media_type=media_type,
             max_input_bytes=max_input_bytes,
         )
-        return _build_run_inputs(file_bytes, file_type)
-
-
-def _prepare_run_inputs_sync(
-    input_file: ExtractionInputLike,
-    media_type: str | None,
-    client: httpx.Client | None = None,
-    *,
-    max_input_bytes: int,
-) -> list:
-    """Resolve one sync media input and build a prompt for retry reuse."""
-    with _extraction_errors():
-        file_bytes, file_type = _get_media(
-            input_file,
-            media_type=media_type,
-            max_input_bytes=max_input_bytes,
-            client=client,
-        )
-        return _build_run_inputs(file_bytes, file_type)
+    with prepared_style_run(style, file_bytes, file_type) as (capabilities, style_inputs):
+        with _extraction_errors():
+            agent = _build_agent(
+                schema,
+                model,
+                instructions,
+                extra_capabilities=capabilities,
+            )
+        yield agent, _resolve_run_inputs(file_bytes, file_type, style_inputs)
 
 
 def _run_extraction(
@@ -1331,6 +1295,7 @@ class _ExtractorSession[T: BaseModel]:
         model: str | Model | None,
         instructions: str | None,
         *,
+        style: ExtractionStyle | str,
         agent: PydanticAgent | None,
         model_settings: ModelSettings | None,
         timeout: float | None,
@@ -1339,6 +1304,7 @@ class _ExtractorSession[T: BaseModel]:
         max_input_bytes: int | None,
         url_timeout: float | None,
     ) -> None:
+        resolved_style = normalize_style(style)
         if agent is not None:
             if model is not None:
                 raise ValueError("model and agent are mutually exclusive; provide exactly one.")
@@ -1349,17 +1315,24 @@ class _ExtractorSession[T: BaseModel]:
                 )
             if instrument is not False:
                 raise ValueError("instrument must be configured on an injected agent.")
+            if resolved_style is not ExtractionStyle.DIRECT:
+                raise ValueError("style other than 'direct' cannot be used with an injected agent.")
             configured_agent = agent
+            session_settings = None
         else:
             if model is None:
                 raise TypeError("model is required unless agent is provided.")
-            configured_agent = _build_agent(
-                schema,
-                model,
-                instructions,
-                model_settings=_session_model_settings(model_settings, timeout),
-                instrument=instrument,
-            )
+            session_settings = _session_model_settings(model_settings, timeout)
+            if resolved_style is ExtractionStyle.DIRECT:
+                configured_agent = _build_agent(
+                    schema,
+                    model,
+                    instructions,
+                    model_settings=session_settings,
+                    instrument=instrument,
+                )
+            else:
+                configured_agent = None
 
         if retry_policy is None:
             retry_policy = RetryPolicy()
@@ -1367,6 +1340,11 @@ class _ExtractorSession[T: BaseModel]:
             raise TypeError("retry_policy must be a RetryPolicy instance.")
 
         self._schema = schema
+        self._model = model
+        self._instructions = instructions
+        self._style = resolved_style
+        self._model_settings = session_settings
+        self._instrument = instrument
         self._agent = configured_agent
         self._retry_policy = retry_policy
         self._max_input_bytes = _resolve_max_input_bytes(max_input_bytes)
@@ -1392,6 +1370,20 @@ class _ExtractorSession[T: BaseModel]:
         if not self._entered:
             raise RuntimeError(f"{class_name} must be used as a context manager before extraction.")
 
+    def _agent_for_run(self, extra_capabilities: Sequence[object]) -> PydanticAgent:
+        if not extra_capabilities:
+            assert self._agent is not None
+            return self._agent
+        assert self._model is not None
+        return _build_agent(
+            self._schema,
+            self._model,
+            self._instructions,
+            model_settings=self._model_settings,
+            instrument=self._instrument,
+            extra_capabilities=extra_capabilities,
+        )
+
 
 class Extractor(_ExtractorSession[T]):
     """Reusable synchronous extraction session.
@@ -1407,6 +1399,7 @@ class Extractor(_ExtractorSession[T]):
         model: str | Model | None = None,
         instructions: str | None = None,
         *,
+        style: ExtractionStyle | str = "direct",
         agent: PydanticAgent | None = None,
         model_settings: ModelSettings | None = None,
         timeout: float | None = None,
@@ -1419,6 +1412,7 @@ class Extractor(_ExtractorSession[T]):
             schema,
             model,
             instructions,
+            style=style,
             agent=agent,
             model_settings=model_settings,
             timeout=timeout,
@@ -1448,7 +1442,8 @@ class Extractor(_ExtractorSession[T]):
         runner = asyncio.Runner(loop_factory=asyncio.new_event_loop)
         runner.__enter__()
         try:
-            runner.run(self._agent.__aenter__())
+            if self._agent is not None:
+                runner.run(self._agent.__aenter__())
         except BaseException:
             client.close()
             runner.close()
@@ -1473,7 +1468,8 @@ class Extractor(_ExtractorSession[T]):
         assert self._client is not None
         suppressed = False
         try:
-            suppressed = bool(self._runner.run(self._agent.__aexit__(*exc_info)))
+            if self._agent is not None:
+                suppressed = bool(self._runner.run(self._agent.__aexit__(*exc_info)))
         finally:
             self._client.close()
             self._runner.close()
@@ -1494,9 +1490,9 @@ class Extractor(_ExtractorSession[T]):
         assert self._client is not None
         return self._client
 
-    def _run_agent(self, inputs: list):
+    def _run_agent(self, agent: PydanticAgent, inputs: list):
         assert self._runner is not None
-        return self._runner.run(_run_extraction_async(self._agent, inputs))
+        return self._runner.run(_run_extraction_async(agent, inputs))
 
     def extract(
         self,
@@ -1506,22 +1502,29 @@ class Extractor(_ExtractorSession[T]):
     ) -> T:
         """Extract one input using the session's reusable agent and clients."""
         client = self._ensure_sync_open()
-        inputs = _prepare_run_inputs_sync(
-            input_file,
-            media_type,
-            client,
-            max_input_bytes=self._max_input_bytes,
-        )
+        with _extraction_errors():
+            file_bytes, file_type = _get_media(
+                input_file,
+                media_type=media_type,
+                max_input_bytes=self._max_input_bytes,
+                client=client,
+            )
+        with prepared_style_run(self._style, file_bytes, file_type) as (
+            capabilities,
+            style_inputs,
+        ):
+            inputs = _resolve_run_inputs(file_bytes, file_type, style_inputs)
+            agent = self._agent_for_run(capabilities)
 
-        def _once() -> T:
-            return self._validate_output(self._run_agent(inputs).output)
+            def _once() -> T:
+                return self._validate_output(self._run_agent(agent, inputs).output)
 
-        return _run_with_retries_sync(
-            _once,
-            max_retries=self._retry_policy.max_retries,
-            retry_backoff=self._retry_policy.backoff,
-            retry_max_backoff=self._retry_policy.max_backoff,
-        )
+            return _run_with_retries_sync(
+                _once,
+                max_retries=self._retry_policy.max_retries,
+                retry_backoff=self._retry_policy.backoff,
+                retry_max_backoff=self._retry_policy.max_backoff,
+            )
 
     def extract_with_usage(
         self,
@@ -1531,23 +1534,30 @@ class Extractor(_ExtractorSession[T]):
     ) -> tuple[T, Usage]:
         """Extract one input and return its successful-call token usage."""
         client = self._ensure_sync_open()
-        inputs = _prepare_run_inputs_sync(
-            input_file,
-            media_type,
-            client,
-            max_input_bytes=self._max_input_bytes,
-        )
+        with _extraction_errors():
+            file_bytes, file_type = _get_media(
+                input_file,
+                media_type=media_type,
+                max_input_bytes=self._max_input_bytes,
+                client=client,
+            )
+        with prepared_style_run(self._style, file_bytes, file_type) as (
+            capabilities,
+            style_inputs,
+        ):
+            inputs = _resolve_run_inputs(file_bytes, file_type, style_inputs)
+            agent = self._agent_for_run(capabilities)
 
-        def _once() -> tuple[T, Usage]:
-            result = self._run_agent(inputs)
-            return self._validate_output(result.output), _usage_from_result(result)
+            def _once() -> tuple[T, Usage]:
+                result = self._run_agent(agent, inputs)
+                return self._validate_output(result.output), _usage_from_result(result)
 
-        return _run_with_retries_sync(
-            _once,
-            max_retries=self._retry_policy.max_retries,
-            retry_backoff=self._retry_policy.backoff,
-            retry_max_backoff=self._retry_policy.max_backoff,
-        )
+            return _run_with_retries_sync(
+                _once,
+                max_retries=self._retry_policy.max_retries,
+                retry_backoff=self._retry_policy.backoff,
+                retry_max_backoff=self._retry_policy.max_backoff,
+            )
 
 
 class AsyncExtractor(_ExtractorSession[T]):
@@ -1559,6 +1569,7 @@ class AsyncExtractor(_ExtractorSession[T]):
         model: str | Model | None = None,
         instructions: str | None = None,
         *,
+        style: ExtractionStyle | str = "direct",
         agent: PydanticAgent | None = None,
         model_settings: ModelSettings | None = None,
         timeout: float | None = None,
@@ -1571,6 +1582,7 @@ class AsyncExtractor(_ExtractorSession[T]):
             schema,
             model,
             instructions,
+            style=style,
             agent=agent,
             model_settings=model_settings,
             timeout=timeout,
@@ -1586,7 +1598,8 @@ class AsyncExtractor(_ExtractorSession[T]):
         self._ensure_enterable(type(self).__name__)
         client = httpx.AsyncClient(follow_redirects=False, timeout=self._url_timeout)
         try:
-            await self._agent.__aenter__()
+            if self._agent is not None:
+                await self._agent.__aenter__()
         except BaseException:
             await client.aclose()
             raise
@@ -1609,7 +1622,8 @@ class AsyncExtractor(_ExtractorSession[T]):
         assert self._client is not None
         suppressed = False
         try:
-            suppressed = bool(await self._agent.__aexit__(*exc_info))
+            if self._agent is not None:
+                suppressed = bool(await self._agent.__aexit__(*exc_info))
         finally:
             await self._client.aclose()
             self._entered = False
@@ -1639,23 +1653,30 @@ class AsyncExtractor(_ExtractorSession[T]):
     ) -> T:
         """Extract one input using the session's reusable agent and clients."""
         client = self._ensure_async_open()
-        inputs = await _prepare_run_inputs_async(
-            input_file,
-            media_type,
-            client,
-            max_input_bytes=self._max_input_bytes,
-        )
+        with _extraction_errors():
+            file_bytes, file_type = await _get_media_async(
+                input_file,
+                client,
+                media_type=media_type,
+                max_input_bytes=self._max_input_bytes,
+            )
+        with prepared_style_run(self._style, file_bytes, file_type) as (
+            capabilities,
+            style_inputs,
+        ):
+            inputs = _resolve_run_inputs(file_bytes, file_type, style_inputs)
+            agent = self._agent_for_run(capabilities)
 
-        async def _once() -> T:
-            result = await _run_extraction_async(self._agent, inputs)
-            return self._validate_output(result.output)
+            async def _once() -> T:
+                result = await _run_extraction_async(agent, inputs)
+                return self._validate_output(result.output)
 
-        return await _run_with_retries_async(
-            _once,
-            max_retries=self._retry_policy.max_retries,
-            retry_backoff=self._retry_policy.backoff,
-            retry_max_backoff=self._retry_policy.max_backoff,
-        )
+            return await _run_with_retries_async(
+                _once,
+                max_retries=self._retry_policy.max_retries,
+                retry_backoff=self._retry_policy.backoff,
+                retry_max_backoff=self._retry_policy.max_backoff,
+            )
 
     async def extract_with_usage(
         self,
@@ -1665,23 +1686,30 @@ class AsyncExtractor(_ExtractorSession[T]):
     ) -> tuple[T, Usage]:
         """Extract one input and return its successful-call token usage."""
         client = self._ensure_async_open()
-        inputs = await _prepare_run_inputs_async(
-            input_file,
-            media_type,
-            client,
-            max_input_bytes=self._max_input_bytes,
-        )
+        with _extraction_errors():
+            file_bytes, file_type = await _get_media_async(
+                input_file,
+                client,
+                media_type=media_type,
+                max_input_bytes=self._max_input_bytes,
+            )
+        with prepared_style_run(self._style, file_bytes, file_type) as (
+            capabilities,
+            style_inputs,
+        ):
+            inputs = _resolve_run_inputs(file_bytes, file_type, style_inputs)
+            agent = self._agent_for_run(capabilities)
 
-        async def _once() -> tuple[T, Usage]:
-            result = await _run_extraction_async(self._agent, inputs)
-            return self._validate_output(result.output), _usage_from_result(result)
+            async def _once() -> tuple[T, Usage]:
+                result = await _run_extraction_async(agent, inputs)
+                return self._validate_output(result.output), _usage_from_result(result)
 
-        return await _run_with_retries_async(
-            _once,
-            max_retries=self._retry_policy.max_retries,
-            retry_backoff=self._retry_policy.backoff,
-            retry_max_backoff=self._retry_policy.max_backoff,
-        )
+            return await _run_with_retries_async(
+                _once,
+                max_retries=self._retry_policy.max_retries,
+                retry_backoff=self._retry_policy.backoff,
+                retry_max_backoff=self._retry_policy.max_backoff,
+            )
 
 
 def extract(
@@ -1690,6 +1718,7 @@ def extract(
     input_file: ExtractionInputLike,
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_retries: int = 0,
@@ -1706,6 +1735,10 @@ def extract(
             a binary file-like object with a ``.read()`` method. For ``bytes``
             and file-like inputs, ``media_type`` must be provided.
         instructions: Optional natural-language guidance for the LLM.
+        style: Extraction strategy. ``direct`` (default) sends the media to the
+            model in one shot. ``search`` gives the model file tools (grep/read)
+            against a text document. ``code`` lets the model write Python against
+            a text document via the Pydantic AI harness.
         media_type: Optional MIME type. Required for ``bytes`` and file-like
             inputs; overrides the guess for ``str`` inputs when provided.
         max_input_bytes: Maximum bytes to load for this input. ``None`` uses
@@ -1728,24 +1761,29 @@ def extract(
         UrlFetchError: If the URL cannot be fetched or returns a non-2xx status.
         SchemaValidationError: If the model output doesn't match the schema.
         ModelError: If retries (if any) are exhausted.
+        ProviderNotInstalledError: If a provider SDK or style extra is missing.
         ExtractionError: For other extraction failures.
+        ValueError: If ``style`` is invalid or ``search``/``code`` is used with
+            a non-text document.
     """
+    style = normalize_style(style)
     _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     limit = _resolve_max_input_bytes(max_input_bytes)
-    agent, inputs = _prepare_extraction(
+    with _prepare_extraction(
         schema,
         model,
         input_file,
         instructions,
         media_type,
         limit,
-    )
-    return _run_with_retries_sync(
-        lambda: _extract_once(agent, inputs),
-        max_retries=max_retries,
-        retry_backoff=retry_backoff,
-        retry_max_backoff=retry_max_backoff,
-    )
+        style,
+    ) as (agent, inputs):
+        return _run_with_retries_sync(
+            lambda: _extract_once(agent, inputs),
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+            retry_max_backoff=retry_max_backoff,
+        )
 
 
 def extract_with_usage(
@@ -1754,6 +1792,7 @@ def extract_with_usage(
     input_file: ExtractionInputLike,
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_retries: int = 0,
@@ -1765,27 +1804,29 @@ def extract_with_usage(
     Same retry semantics as :func:`extract`. Returns a :class:`Usage` describing
     the tokens consumed by the successful model call.
     """
+    style = normalize_style(style)
     _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     limit = _resolve_max_input_bytes(max_input_bytes)
-    agent, inputs = _prepare_extraction(
+    with _prepare_extraction(
         schema,
         model,
         input_file,
         instructions,
         media_type,
         limit,
-    )
+        style,
+    ) as (agent, inputs):
 
-    def _once() -> tuple[T, Usage]:
-        result = _run_extraction(agent, inputs)
-        return cast(T, result.output), _usage_from_result(result)
+        def _once() -> tuple[T, Usage]:
+            result = _run_extraction(agent, inputs)
+            return cast(T, result.output), _usage_from_result(result)
 
-    return _run_with_retries_sync(
-        _once,
-        max_retries=max_retries,
-        retry_backoff=retry_backoff,
-        retry_max_backoff=retry_max_backoff,
-    )
+        return _run_with_retries_sync(
+            _once,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+            retry_max_backoff=retry_max_backoff,
+        )
 
 
 async def extract_with_usage_async(
@@ -1794,6 +1835,7 @@ async def extract_with_usage_async(
     input_file: ExtractionInputLike,
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_retries: int = 0,
@@ -1801,27 +1843,29 @@ async def extract_with_usage_async(
     retry_max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF,
 ) -> tuple[T, Usage]:
     """Async sibling of :func:`extract_with_usage`; returns ``(output, Usage)``."""
+    style = normalize_style(style)
     _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     limit = _resolve_max_input_bytes(max_input_bytes)
-    agent, inputs = await _prepare_extraction_async(
+    async with _prepare_extraction_async(
         schema,
         model,
         input_file,
         instructions,
         media_type,
         limit,
-    )
+        style,
+    ) as (agent, inputs):
 
-    async def _once() -> tuple[T, Usage]:
-        result = await _run_extraction_async(agent, inputs)
-        return cast(T, result.output), _usage_from_result(result)
+        async def _once() -> tuple[T, Usage]:
+            result = await _run_extraction_async(agent, inputs)
+            return cast(T, result.output), _usage_from_result(result)
 
-    return await _run_with_retries_async(
-        _once,
-        max_retries=max_retries,
-        retry_backoff=retry_backoff,
-        retry_max_backoff=retry_max_backoff,
-    )
+        return await _run_with_retries_async(
+            _once,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+            retry_max_backoff=retry_max_backoff,
+        )
 
 
 async def extract_async(
@@ -1830,6 +1874,7 @@ async def extract_async(
     input_file: ExtractionInputLike,
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_retries: int = 0,
@@ -1837,27 +1882,29 @@ async def extract_async(
     retry_max_backoff: float = _DEFAULT_RETRY_MAX_BACKOFF,
 ) -> T:
     """Async sibling of :func:`extract`; uses ``Agent.run`` instead of ``run_sync``."""
+    style = normalize_style(style)
     _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     limit = _resolve_max_input_bytes(max_input_bytes)
-    agent, inputs = await _prepare_extraction_async(
+    async with _prepare_extraction_async(
         schema,
         model,
         input_file,
         instructions,
         media_type,
         limit,
-    )
+        style,
+    ) as (agent, inputs):
 
-    async def _once() -> T:
-        result = await _run_extraction_async(agent, inputs)
-        return cast(T, result.output)
+        async def _once() -> T:
+            result = await _run_extraction_async(agent, inputs)
+            return cast(T, result.output)
 
-    return await _run_with_retries_async(
-        _once,
-        max_retries=max_retries,
-        retry_backoff=retry_backoff,
-        retry_max_backoff=retry_max_backoff,
-    )
+        return await _run_with_retries_async(
+            _once,
+            max_retries=max_retries,
+            retry_backoff=retry_backoff,
+            retry_max_backoff=retry_max_backoff,
+        )
 
 
 async def _run_with_shared_agent(
@@ -1908,6 +1955,7 @@ async def _iter_extractions(
     retry_backoff: float,
     retry_max_backoff: float,
     rich: bool = False,
+    style: ExtractionStyle = ExtractionStyle.DIRECT,
 ) -> AsyncIterator[tuple[int, T | ExtractionResult[T] | Exception]]:
     """Yield indexed batch results in completion order with bounded work.
 
@@ -1922,8 +1970,12 @@ async def _iter_extractions(
 
     # Building the Agent (and its provider HTTP client) is ~32 ms; sharing one
     # across the batch saves ~32 ms × (N-1) per call. The Agent is stateless
-    # between runs and stays inside this event loop, so this is safe.
-    agent = _build_agent(schema, model, instructions)
+    # between runs and stays inside this event loop, so this is safe. Search and
+    # code styles bind capabilities to a per-item workspace, so those items
+    # each get their own agent.
+    shared_agent = (
+        _build_agent(schema, model, instructions) if style is ExtractionStyle.DIRECT else None
+    )
     stop = asyncio.Event()
     pending: dict[asyncio.Task[object], int] = {}
     next_index = 0
@@ -1939,30 +1991,46 @@ async def _iter_extractions(
             started = time.perf_counter()
             attempts = 0
             try:
-                inputs = await _prepare_run_inputs_async(
-                    source,
-                    item_media_type,
-                    client,
-                    max_input_bytes=max_input_bytes,
-                )
+                with _extraction_errors():
+                    file_bytes, file_type = await _get_media_async(
+                        source,
+                        client,
+                        media_type=item_media_type,
+                        max_input_bytes=max_input_bytes,
+                    )
+                with prepared_style_run(style, file_bytes, file_type) as (
+                    capabilities,
+                    style_inputs,
+                ):
+                    inputs = _resolve_run_inputs(file_bytes, file_type, style_inputs)
+                    if shared_agent is None:
+                        with _extraction_errors():
+                            run_agent = _build_agent(
+                                schema,
+                                model,
+                                instructions,
+                                extra_capabilities=capabilities,
+                            )
+                    else:
+                        run_agent = shared_agent
 
-                async def _once() -> object:
-                    nonlocal attempts
-                    attempts += 1
-                    # A sibling may have failed while this item was being prepared
-                    # or waiting to retry. Do not begin another model call afterward.
-                    if stop.is_set():
-                        raise asyncio.CancelledError
-                    if rich:
-                        return await _run_with_shared_agent_result(agent, inputs)
-                    return await _run_with_shared_agent(agent, inputs)
+                    async def _once() -> object:
+                        nonlocal attempts
+                        attempts += 1
+                        # A sibling may have failed while this item was being prepared
+                        # or waiting to retry. Do not begin another model call afterward.
+                        if stop.is_set():
+                            raise asyncio.CancelledError
+                        if rich:
+                            return await _run_with_shared_agent_result(run_agent, inputs)
+                        return await _run_with_shared_agent(run_agent, inputs)
 
-                value = await _run_with_retries_async(
-                    _once,
-                    max_retries=max_retries,
-                    retry_backoff=retry_backoff,
-                    retry_max_backoff=retry_max_backoff,
-                )
+                    value = await _run_with_retries_async(
+                        _once,
+                        max_retries=max_retries,
+                        retry_backoff=retry_backoff,
+                        retry_max_backoff=retry_max_backoff,
+                    )
                 if rich:
                     raw_result = cast(Any, value)
                     return ExtractionResult(
@@ -1970,7 +2038,7 @@ async def _iter_extractions(
                         usage=_usage_from_result(raw_result),
                         attempts=attempts,
                         duration=time.perf_counter() - started,
-                        model=_model_identifier(model, agent),
+                        model=_model_identifier(model, run_agent),
                         media_type=item_media_type,
                         source=_item_source_label(source, name),
                         warnings=(),
@@ -2054,6 +2122,7 @@ async def _gather_extractions(
     retry_backoff: float,
     retry_max_backoff: float,
     rich: bool = False,
+    style: ExtractionStyle = ExtractionStyle.DIRECT,
 ) -> list:
     _validate_retry_options(max_retries, retry_backoff, retry_max_backoff)
     _validate_max_concurrency(max_concurrency)
@@ -2073,6 +2142,7 @@ async def _gather_extractions(
             retry_backoff,
             retry_max_backoff,
             rich,
+            style,
         )
     ]
     indexed_results.sort(key=lambda item: item[0])
@@ -2086,6 +2156,7 @@ def extract_many(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2103,6 +2174,7 @@ def extract_many(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2120,6 +2192,7 @@ def extract_many(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2136,6 +2209,7 @@ def extract_many(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2203,6 +2277,7 @@ def extract_many(
             max_retries,
             retry_backoff,
             retry_max_backoff,
+            style=normalize_style(style),
         )
     )
 
@@ -2214,6 +2289,7 @@ async def extract_many_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2231,6 +2307,7 @@ async def extract_many_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2248,6 +2325,7 @@ async def extract_many_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2264,6 +2342,7 @@ async def extract_many_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2285,6 +2364,7 @@ async def extract_many_async(
         max_retries,
         retry_backoff,
         retry_max_backoff,
+        style=normalize_style(style),
     )
 
 
@@ -2295,6 +2375,7 @@ def iter_extract_many_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2312,6 +2393,7 @@ def iter_extract_many_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2329,6 +2411,7 @@ def iter_extract_many_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2345,6 +2428,7 @@ def iter_extract_many_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2386,6 +2470,7 @@ def iter_extract_many_async(
             max_retries,
             retry_backoff,
             retry_max_backoff,
+            style=normalize_style(style),
         ),
     )
 
@@ -2397,6 +2482,7 @@ def extract_many_with_results(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2414,6 +2500,7 @@ def extract_many_with_results(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2431,6 +2518,7 @@ def extract_many_with_results(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2447,6 +2535,7 @@ def extract_many_with_results(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2514,6 +2603,7 @@ def extract_many_with_results(
             retry_backoff,
             retry_max_backoff,
             rich=True,
+            style=normalize_style(style),
         )
     )
 
@@ -2525,6 +2615,7 @@ async def extract_many_with_results_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2542,6 +2633,7 @@ async def extract_many_with_results_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2559,6 +2651,7 @@ async def extract_many_with_results_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2575,6 +2668,7 @@ async def extract_many_with_results_async(
     input_files: Iterable[ExtractionInputLike],
     instructions: str | None = None,
     *,
+    style: ExtractionStyle | str = "direct",
     media_type: str | None = None,
     max_input_bytes: int | None = None,
     max_concurrency: int = 5,
@@ -2597,4 +2691,5 @@ async def extract_many_with_results_async(
         retry_backoff,
         retry_max_backoff,
         rich=True,
+        style=normalize_style(style),
     )

--- a/src/openextract/_styles.py
+++ b/src/openextract/_styles.py
@@ -11,7 +11,19 @@ from pathlib import Path
 from .exceptions import ProviderNotInstalledError
 
 _CODE_VIRTUAL_ROOT = "/work"
-_BINARY_MEDIA_PREFIXES = ("image/", "audio/", "video/")
+# The pydantic-ai-harness version line the FileSystem/CodeMode integration was
+# written against. The repo's locked dev environment cannot install it (it
+# requires pydantic-ai-slim 2.x), so CI does not exercise the live harness.
+_HARNESS_TARGET_VERSION = "0.18.x"
+_BINARY_MEDIA_PREFIXES = (
+    "image/",
+    "audio/",
+    "video/",
+    # Office container families as reported by ``mimetypes.guess_type``, which
+    # backs the repo's media-type detection for path and URL inputs.
+    "application/vnd.openxmlformats-officedocument.",
+    "application/vnd.oasis.opendocument.",
+)
 _BINARY_MEDIA_TYPES = frozenset(
     {
         "application/pdf",
@@ -19,6 +31,9 @@ _BINARY_MEDIA_TYPES = frozenset(
         "application/gzip",
         "application/x-gzip",
         "application/x-tar",
+        "application/msword",
+        "application/vnd.ms-excel",
+        "application/vnd.ms-powerpoint",
     }
 )
 _TEXT_APPLICATION_TYPES = frozenset(
@@ -153,7 +168,9 @@ def _search_capabilities(workspace: Path) -> list[object]:
         raise ProviderNotInstalledError(
             "style='search' requires pydantic-ai-harness. "
             "Install it with: pip install pydantic-ai-harness "
-            f"(or 'pip install pydantic-ai-harness[codemode]'). Original error: {exc}"
+            "(or 'pip install pydantic-ai-harness[codemode]'). "
+            f"The integration targets pydantic-ai-harness {_HARNESS_TARGET_VERSION}. "
+            f"Original error: {exc}"
         ) from exc
     return [filesystem(root_dir=workspace)]
 
@@ -164,9 +181,10 @@ def _code_capabilities(workspace: Path) -> list[object]:
         monty = __import__("pydantic_monty", fromlist=["MountDir"])
     except ImportError as exc:
         raise ProviderNotInstalledError(
-            "style='code' requires pydantic-ai-harness with the code-mode extra. "
-            "Install it with: pip install 'pydantic-ai-harness[codemode]' "
-            f"(or 'pip install pydantic-ai-harness[code-mode]'). Original error: {exc}"
+            "style='code' requires pydantic-ai-harness with the codemode extra. "
+            "Install it with: pip install 'pydantic-ai-harness[codemode]'. "
+            f"The integration targets pydantic-ai-harness {_HARNESS_TARGET_VERSION}. "
+            f"Original error: {exc}"
         ) from exc
     return [
         harness.CodeMode(

--- a/src/openextract/_styles.py
+++ b/src/openextract/_styles.py
@@ -1,0 +1,225 @@
+"""Out-of-the-box extraction styles backed by the Pydantic AI harness."""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from enum import StrEnum
+from pathlib import Path
+
+from .exceptions import ProviderNotInstalledError
+
+_CODE_VIRTUAL_ROOT = "/work"
+_BINARY_MEDIA_PREFIXES = ("image/", "audio/", "video/")
+_BINARY_MEDIA_TYPES = frozenset(
+    {
+        "application/pdf",
+        "application/zip",
+        "application/gzip",
+        "application/x-gzip",
+        "application/x-tar",
+    }
+)
+_TEXT_APPLICATION_TYPES = frozenset(
+    {
+        "application/csv",
+        "application/graphql",
+        "application/javascript",
+        "application/json",
+        "application/ld+json",
+        "application/sql",
+        "application/toml",
+        "application/xml",
+        "application/x-ndjson",
+        "application/x-sh",
+        "application/x-yaml",
+        "application/yaml",
+    }
+)
+_DOCUMENT_FILENAMES = {
+    "csv": "document.csv",
+    "html": "document.html",
+    "javascript": "document.js",
+    "json": "document.json",
+    "ld+json": "document.json",
+    "markdown": "document.md",
+    "plain": "document.txt",
+    "tab-separated-values": "document.tsv",
+    "toml": "document.toml",
+    "x-markdown": "document.md",
+    "x-ndjson": "document.ndjson",
+    "x-sh": "document.sh",
+    "x-yaml": "document.yaml",
+    "xml": "document.xml",
+    "yaml": "document.yaml",
+}
+
+
+class ExtractionStyle(StrEnum):
+    """How an extraction run inspects the input.
+
+    ``direct``
+        Pass the media bytes to the model in one shot (default).
+    ``search``
+        For text, give the model sandboxed file tools (read, regex search,
+        glob) against a workspace copy of the document.
+    ``code``
+        For text, give the model a sandboxed ``run_code`` tool that can open
+        and parse the document with Python.
+    """
+
+    DIRECT = "direct"
+    SEARCH = "search"
+    CODE = "code"
+
+
+def normalize_style(style: ExtractionStyle | str) -> ExtractionStyle:
+    """Return a valid :class:`ExtractionStyle` or raise ``ValueError``."""
+    try:
+        return ExtractionStyle(style)
+    except ValueError:
+        allowed = ", ".join(repr(item.value) for item in ExtractionStyle)
+        raise ValueError(f"style must be one of {allowed}; got {style!r}.") from None
+
+
+def _bare_media_type(media_type: str) -> str:
+    return media_type.split(";", 1)[0].strip().lower()
+
+
+def is_text_media_type(media_type: str) -> bool:
+    """Return whether ``media_type`` is a known textual MIME type."""
+    bare = _bare_media_type(media_type)
+    return (
+        bare.startswith("text/")
+        or bare in _TEXT_APPLICATION_TYPES
+        or bare.endswith(("+json", "+xml", "+yaml"))
+    )
+
+
+def is_binary_media_type(media_type: str) -> bool:
+    """Return whether ``media_type`` is a known non-text MIME type."""
+    bare = _bare_media_type(media_type)
+    return bare.startswith(_BINARY_MEDIA_PREFIXES) or bare in _BINARY_MEDIA_TYPES
+
+
+def document_filename(media_type: str) -> str:
+    """Return a stable workspace filename for a textual media type."""
+    subtype = _bare_media_type(media_type).rsplit("/", 1)[-1]
+    return _DOCUMENT_FILENAMES.get(subtype, "document.txt")
+
+
+def decode_text_document(data: bytes, media_type: str, *, style: ExtractionStyle) -> str:
+    """Decode UTF-8 text for search/code styles; reject binary inputs."""
+    if is_binary_media_type(media_type) and not is_text_media_type(media_type):
+        raise ValueError(
+            f"style {style.value!r} requires a text document; got media_type={media_type!r}. "
+            "Use style='direct' for PDFs, images, audio, and video."
+        )
+    if b"\x00" in data:
+        raise ValueError(
+            f"style {style.value!r} requires a text document; the input contains NUL bytes. "
+            "Use style='direct' instead."
+        )
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ValueError(
+            f"style {style.value!r} requires UTF-8 text; the input is not valid UTF-8. "
+            "Use style='direct' instead."
+        ) from exc
+
+
+def materialize_text_document(
+    workspace: Path,
+    data: bytes,
+    media_type: str,
+    *,
+    style: ExtractionStyle,
+) -> str:
+    """Write the decoded document into ``workspace`` and return its filename."""
+    filename = document_filename(media_type)
+    (workspace / filename).write_text(
+        decode_text_document(data, media_type, style=style),
+        encoding="utf-8",
+    )
+    return filename
+
+
+def _search_capabilities(workspace: Path) -> list[object]:
+    try:
+        filesystem = __import__("pydantic_ai_harness", fromlist=["FileSystem"]).FileSystem
+    except ImportError as exc:
+        raise ProviderNotInstalledError(
+            "style='search' requires pydantic-ai-harness. "
+            "Install it with: pip install pydantic-ai-harness "
+            f"(or 'pip install pydantic-ai-harness[codemode]'). Original error: {exc}"
+        ) from exc
+    return [filesystem(root_dir=workspace)]
+
+
+def _code_capabilities(workspace: Path) -> list[object]:
+    try:
+        harness = __import__("pydantic_ai_harness", fromlist=["CodeMode"])
+        monty = __import__("pydantic_monty", fromlist=["MountDir"])
+    except ImportError as exc:
+        raise ProviderNotInstalledError(
+            "style='code' requires pydantic-ai-harness with the code-mode extra. "
+            "Install it with: pip install 'pydantic-ai-harness[codemode]' "
+            f"(or 'pip install pydantic-ai-harness[code-mode]'). Original error: {exc}"
+        ) from exc
+    return [
+        harness.CodeMode(
+            mount=monty.MountDir(
+                virtual_path=_CODE_VIRTUAL_ROOT,
+                host_path=workspace,
+                mode="read-only",
+            )
+        )
+    ]
+
+
+def style_capabilities(style: ExtractionStyle, workspace: Path) -> list[object]:
+    """Return Pydantic AI capabilities that implement ``style``."""
+    if style is ExtractionStyle.SEARCH:
+        return _search_capabilities(workspace)
+    if style is ExtractionStyle.CODE:
+        return _code_capabilities(workspace)
+    return []
+
+
+def style_run_inputs(style: ExtractionStyle, filename: str) -> list[str]:
+    """Return the user prompt for a search or code extraction."""
+    if style is ExtractionStyle.SEARCH:
+        return [
+            "Extract the requested information from the document "
+            f"{filename!r} in the workspace. Use search_files, read_file, "
+            "find_files, list_directory, and file_info to inspect it. Search "
+            "before reading large files; do not assume unseen contents."
+        ]
+    return [
+        "Extract the requested information by writing Python against "
+        f"{_CODE_VIRTUAL_ROOT}/{filename}. Read the file with pathlib or "
+        "open(), then parse, filter, and compute the structured result."
+    ]
+
+
+@contextmanager
+def prepared_style_run(
+    style: ExtractionStyle,
+    file_bytes: bytes,
+    file_type: str,
+) -> Iterator[tuple[list[object], list[str] | None]]:
+    """Yield ``(extra_capabilities, run_inputs)`` for one extraction.
+
+    ``direct`` yields no extra capabilities and ``None`` inputs so the caller
+    can pass media as ``BinaryContent``. ``search`` and ``code`` materialize a
+    UTF-8 workspace that lives until the context exits, including retries.
+    """
+    if style is ExtractionStyle.DIRECT:
+        yield [], None
+        return
+    with tempfile.TemporaryDirectory(prefix="openextract-") as tmp:
+        workspace = Path(tmp)
+        filename = materialize_text_document(workspace, file_bytes, file_type, style=style)
+        yield style_capabilities(style, workspace), style_run_inputs(style, filename)

--- a/src/openextract/exceptions.py
+++ b/src/openextract/exceptions.py
@@ -36,11 +36,12 @@ class ModelError(ExtractionError):
 
 
 class ProviderNotInstalledError(ExtractionError):
-    """The SDK for the requested model's provider is not installed.
+    """A required optional extra is not installed.
 
     Raised when a model is requested whose provider extra was not installed,
     e.g. calling ``extract(..., model="openai:gpt-4o")`` without first running
-    ``pip install 'openextract[openai]'``.
+    ``pip install 'openextract[openai]'``, or when ``style='search'`` /
+    ``style='code'`` is used without ``pydantic-ai-harness``.
     """
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -204,6 +204,7 @@ class TestMainSuccess:
             model="xai:grok-4.3",
             input_file="input.txt",
             instructions="find the person",
+            style="direct",
             media_type=None,
             max_input_bytes=None,
             max_retries=0,

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -30,6 +30,7 @@ ALL_MODULES = [
     "examples.advanced.extract_with_usage",
     "examples.advanced.retry_extract",
     "examples.advanced.reusable_sessions",
+    "examples.advanced.extraction_styles",
     "examples.advanced.error_handling",
     "examples.audio.meeting_notes",
 ]
@@ -84,6 +85,12 @@ def test_reusable_sessions_example() -> None:
     result = _run("examples.advanced.reusable_sessions")
     assert result.returncode == 0, result.stderr
     assert result.stdout.count("ada@example.com") == 2
+
+
+def test_extraction_styles_example() -> None:
+    result = _run("examples.advanced.extraction_styles")
+    assert result.returncode == 0, result.stderr
+    assert "Q4 notes" in result.stdout
 
 
 @pytest.mark.integration

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import threading
 import time
+from contextlib import nullcontext
 from dataclasses import FrozenInstanceError
 from pathlib import Path
 from types import SimpleNamespace
@@ -131,6 +132,7 @@ def test_star_import_exposes_only_existing_names():
         "RetryPolicy",
         "ExtractionInput",
         "ExtractionResult",
+        "ExtractionStyle",
         "extract",
         "extract_async",
         "extract_many",
@@ -1721,7 +1723,7 @@ class TestExtractRetry:
         expected = _Person(name="Grace", age=85)
         mocker.patch(
             "openextract._extract._prepare_extraction",
-            return_value=(MagicMock(), ["prepared"]),
+            return_value=nullcontext((MagicMock(), ["prepared"])),
         )
         once = mocker.patch(
             "openextract._extract._extract_once",
@@ -1746,7 +1748,7 @@ class TestExtractRetry:
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
         prepare = mocker.patch(
             "openextract._extract._prepare_extraction",
-            return_value=(MagicMock(), ["prepared"]),
+            return_value=nullcontext((MagicMock(), ["prepared"])),
         )
         once = mocker.patch(
             "openextract._extract._extract_once",
@@ -1764,7 +1766,7 @@ class TestExtractRetry:
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
         prepare = mocker.patch(
             "openextract._extract._prepare_extraction",
-            return_value=(MagicMock(), ["prepared"]),
+            return_value=nullcontext((MagicMock(), ["prepared"])),
         )
         expected = _Person(name="Grace", age=85)
         once = mocker.patch(
@@ -1789,7 +1791,7 @@ class TestExtractRetry:
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
         mocker.patch(
             "openextract._extract._prepare_extraction",
-            return_value=(MagicMock(), ["prepared"]),
+            return_value=nullcontext((MagicMock(), ["prepared"])),
         )
         once = mocker.patch(
             "openextract._extract._extract_once",
@@ -1815,7 +1817,7 @@ class TestExtractRetry:
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
         prepare = mocker.patch(
             "openextract._extract._prepare_extraction",
-            return_value=(MagicMock(), ["prepared"]),
+            return_value=nullcontext((MagicMock(), ["prepared"])),
         )
         once = mocker.patch(
             "openextract._extract._extract_once",
@@ -1838,7 +1840,7 @@ class TestExtractRetry:
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
         mocker.patch(
             "openextract._extract._prepare_extraction",
-            return_value=(MagicMock(), ["prepared"]),
+            return_value=nullcontext((MagicMock(), ["prepared"])),
         )
         mocker.patch(
             "openextract._extract._extract_once",
@@ -1865,7 +1867,7 @@ class TestExtractRetry:
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
         mocker.patch(
             "openextract._extract._prepare_extraction",
-            return_value=(MagicMock(), ["prepared"]),
+            return_value=nullcontext((MagicMock(), ["prepared"])),
         )
         mocker.patch(
             "openextract._extract._extract_once",
@@ -1888,7 +1890,7 @@ class TestExtractRetry:
         expected = _Person(name="Grace", age=85)
         mocker.patch(
             "openextract._extract._prepare_extraction",
-            return_value=(MagicMock(), ["prepared"]),
+            return_value=nullcontext((MagicMock(), ["prepared"])),
         )
         mocker.patch(
             "openextract._extract._extract_once",
@@ -1912,7 +1914,7 @@ class TestExtractRetry:
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
         prepare = mocker.patch(
             "openextract._extract._prepare_extraction",
-            return_value=(MagicMock(), ["prepared"]),
+            return_value=nullcontext((MagicMock(), ["prepared"])),
         )
         once = mocker.patch(
             "openextract._extract._extract_once",
@@ -1972,7 +1974,7 @@ class TestExtractWithUsageRetry:
         sleep_mock = mocker.patch("openextract._extract.time.sleep")
         prepare = mocker.patch(
             "openextract._extract._prepare_extraction",
-            return_value=(MagicMock(), ["prepared"]),
+            return_value=nullcontext((MagicMock(), ["prepared"])),
         )
         expected = _Person(name="Ada", age=36)
         usage = MagicMock(input_tokens=1, output_tokens=2, total_tokens=3)
@@ -2366,13 +2368,17 @@ def _stub_shared_agent(mocker, side_effect):
     """
     mocker.patch("openextract._extract._build_agent", return_value=MagicMock())
 
-    async def prepare(input_file, media_type, client, *, max_input_bytes):
-        return [input_file, media_type, client]
+    async def get_media(input_file, client=None, media_type=None, *, max_input_bytes=None):
+        return (input_file, media_type, client), "text/plain"
+
+    def resolve_inputs(file_bytes, file_type, style_inputs):
+        return list(file_bytes)
 
     async def run(agent, inputs):
         return await side_effect(agent, inputs[0], inputs[1], inputs[2])
 
-    mocker.patch("openextract._extract._prepare_run_inputs_async", side_effect=prepare)
+    mocker.patch("openextract._extract._get_media_async", side_effect=get_media)
+    mocker.patch("openextract._extract._resolve_run_inputs", side_effect=resolve_inputs)
     mocker.patch(
         "openextract._extract._run_with_shared_agent",
         side_effect=run,
@@ -2399,13 +2405,17 @@ def _stub_shared_agent_result(mocker, side_effect):
 
     mocker.patch("openextract._extract._build_agent", return_value=MagicMock())
 
-    async def prepare(input_file, media_type, client, *, max_input_bytes):
-        return [input_file, media_type, client]
+    async def get_media(input_file, client=None, media_type=None, *, max_input_bytes=None):
+        return (input_file, media_type, client), "text/plain"
+
+    def resolve_inputs(file_bytes, file_type, style_inputs):
+        return list(file_bytes)
 
     async def run(agent, inputs):
         return await side_effect(agent, inputs[0], inputs[1], inputs[2])
 
-    mocker.patch("openextract._extract._prepare_run_inputs_async", side_effect=prepare)
+    mocker.patch("openextract._extract._get_media_async", side_effect=get_media)
+    mocker.patch("openextract._extract._resolve_run_inputs", side_effect=resolve_inputs)
     mocker.patch(
         "openextract._extract._run_with_shared_agent_result",
         side_effect=run,

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -1,0 +1,347 @@
+"""Tests for extraction styles."""
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic_ai import BinaryContent
+
+from openextract import (
+    AsyncExtractor,
+    ExtractionStyle,
+    Extractor,
+    ProviderNotInstalledError,
+    extract,
+    extract_async,
+    extract_many,
+    extract_with_usage,
+    extract_with_usage_async,
+)
+from openextract._cli import main
+from openextract._styles import (
+    decode_text_document,
+    document_filename,
+    is_binary_media_type,
+    is_text_media_type,
+    materialize_text_document,
+    normalize_style,
+    prepared_style_run,
+    style_capabilities,
+    style_run_inputs,
+)
+from tests.test_extract import _make_agent_mock, _Person
+
+
+def _install_harness(mocker, *, filesystem=None, code_mode=None, mount_dir=None):
+    harness = SimpleNamespace(
+        FileSystem=filesystem or MagicMock(return_value="fs-cap"),
+        CodeMode=code_mode or MagicMock(return_value="code-cap"),
+    )
+    monty = SimpleNamespace(MountDir=mount_dir or MagicMock(return_value="mount"))
+    mocker.patch.dict(sys.modules, {"pydantic_ai_harness": harness, "pydantic_monty": monty})
+    return harness, monty
+
+
+class TestStyleHelpers:
+    def test_normalize_accepts_enum_and_string(self):
+        assert normalize_style("search") is ExtractionStyle.SEARCH
+        assert normalize_style(ExtractionStyle.CODE) is ExtractionStyle.CODE
+
+    def test_normalize_rejects_unknown(self):
+        with pytest.raises(ValueError, match="style must be one of"):
+            normalize_style("rag")
+
+    @pytest.mark.parametrize(
+        ("media_type", "filename"),
+        [
+            ("text/plain", "document.txt"),
+            ("application/json; charset=utf-8", "document.json"),
+            ("text/markdown", "document.md"),
+            ("application/yaml", "document.yaml"),
+            ("text/unknown", "document.txt"),
+        ],
+    )
+    def test_document_filename(self, media_type, filename):
+        assert document_filename(media_type) == filename
+
+    def test_text_and_binary_media_types(self):
+        assert is_text_media_type("text/plain")
+        assert is_text_media_type("application/json")
+        assert is_text_media_type("application/vnd.api+json")
+        assert is_binary_media_type("image/png")
+        assert is_binary_media_type("application/pdf")
+        assert not is_binary_media_type("text/plain")
+
+    def test_decode_rejects_pdf_and_nul_and_invalid_utf8(self):
+        with pytest.raises(ValueError, match="style 'search' requires a text document"):
+            decode_text_document(b"%PDF", "application/pdf", style=ExtractionStyle.SEARCH)
+        with pytest.raises(ValueError, match="NUL bytes"):
+            decode_text_document(b"a\x00b", "text/plain", style=ExtractionStyle.CODE)
+        with pytest.raises(ValueError, match="valid UTF-8"):
+            decode_text_document(b"\xff", "text/plain", style=ExtractionStyle.SEARCH)
+
+    def test_decode_accepts_octet_stream_utf8(self):
+        assert (
+            decode_text_document(b"hello", "application/octet-stream", style=ExtractionStyle.SEARCH)
+            == "hello"
+        )
+
+    def test_materialize_writes_workspace_file(self, tmp_path):
+        name = materialize_text_document(
+            tmp_path, b'{"a": 1}', "application/json", style=ExtractionStyle.CODE
+        )
+        assert name == "document.json"
+        assert (tmp_path / name).read_text(encoding="utf-8") == '{"a": 1}'
+
+    def test_direct_capabilities_are_empty(self, tmp_path):
+        assert style_capabilities(ExtractionStyle.DIRECT, tmp_path) == []
+
+    def test_style_run_inputs_mention_tools_or_code(self):
+        search = style_run_inputs(ExtractionStyle.SEARCH, "document.txt")
+        code = style_run_inputs(ExtractionStyle.CODE, "document.txt")
+        assert "search_files" in search[0]
+        assert "/work/document.txt" in code[0]
+
+
+class TestPreparedStyleRun:
+    def test_direct_yields_no_workspace_inputs(self):
+        with prepared_style_run(ExtractionStyle.DIRECT, b"abc", "text/plain") as (
+            caps,
+            inputs,
+        ):
+            assert caps == []
+            assert inputs is None
+
+    def test_search_materializes_and_cleans_up(self, mocker):
+        harness, _ = _install_harness(mocker)
+        with prepared_style_run(ExtractionStyle.SEARCH, b"body", "text/plain") as (
+            caps,
+            inputs,
+        ):
+            root = harness.FileSystem.call_args.kwargs["root_dir"]
+            assert (root / "document.txt").read_text(encoding="utf-8") == "body"
+            assert caps == [harness.FileSystem.return_value]
+            assert "search_files" in inputs[0]
+        assert not root.exists()
+
+
+class TestExtractStyles:
+    def test_invalid_style_is_rejected_before_agent_build(self, mocker):
+        agent = mocker.patch("openextract._extract.Agent")
+        with pytest.raises(ValueError, match="style must be one of"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file=b"x",
+                media_type="text/plain",
+                style="nope",
+            )
+        agent.assert_not_called()
+
+    def test_search_requires_harness_extra(self, mocker):
+        mocker.patch.dict(sys.modules, {"pydantic_ai_harness": None})
+        mocker.patch("openextract._extract.Agent")
+        with pytest.raises(ProviderNotInstalledError, match="pydantic-ai-harness"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file=b"Ada is 36",
+                media_type="text/plain",
+                style="search",
+            )
+
+    def test_code_requires_code_extra(self, mocker):
+        mocker.patch.dict(sys.modules, {"pydantic_ai_harness": None, "pydantic_monty": None})
+        mocker.patch("openextract._extract.Agent")
+        with pytest.raises(ProviderNotInstalledError, match="codemode"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file=b"Ada is 36",
+                media_type="text/plain",
+                style="code",
+            )
+
+    def test_search_passes_filesystem_capability_not_binary(self, mocker):
+        harness, _ = _install_harness(mocker)
+        expected = _Person(name="Ada", age=36)
+        agent_cls, agent = _make_agent_mock(mocker, output=expected)
+
+        result = extract(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=b"Ada is 36",
+            media_type="text/plain",
+            style="search",
+        )
+
+        assert result is expected
+        assert agent_cls.call_args.kwargs["capabilities"] == [harness.FileSystem.return_value]
+        prompt = agent.run_sync.call_args.args[0]
+        assert all(not isinstance(part, BinaryContent) for part in prompt)
+        assert "search_files" in prompt[0]
+
+    def test_code_mounts_workspace_read_only(self, mocker):
+        harness, monty = _install_harness(mocker)
+        expected = _Person(name="Ada", age=36)
+        agent_cls, agent = _make_agent_mock(mocker, output=expected)
+
+        result = extract(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=b"Ada is 36",
+            media_type="text/plain",
+            style=ExtractionStyle.CODE,
+        )
+
+        assert result is expected
+        monty.MountDir.assert_called_once()
+        assert monty.MountDir.call_args.kwargs["virtual_path"] == "/work"
+        assert monty.MountDir.call_args.kwargs["mode"] == "read-only"
+        harness.CodeMode.assert_called_once_with(mount=monty.MountDir.return_value)
+        assert agent_cls.call_args.kwargs["capabilities"] == [harness.CodeMode.return_value]
+        assert "/work/document.txt" in agent.run_sync.call_args.args[0][0]
+
+    def test_search_rejects_images(self, mocker):
+        mocker.patch("openextract._extract.Agent")
+        with pytest.raises(ValueError, match="style 'search' requires a text document"):
+            extract(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file=b"\x89PNG",
+                media_type="image/png",
+                style="search",
+            )
+
+    def test_usage_and_async_search(self, mocker):
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        _install_harness(mocker)
+        expected = _Person(name="Ada", age=36)
+        usage = SimpleNamespace(input_tokens=1, output_tokens=2, total_tokens=3)
+        _, agent = _make_agent_mock(mocker, output=expected, usage=usage)
+        run_result = agent.run_sync.return_value
+        agent.run = AsyncMock(return_value=run_result)
+
+        output, tokens = extract_with_usage(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=b"Ada",
+            media_type="text/plain",
+            style="search",
+        )
+        assert output is expected
+        assert tokens.total_tokens == 3
+
+        async_output, async_tokens = asyncio.run(
+            extract_with_usage_async(
+                schema=_Person,
+                model="openai:gpt-5",
+                input_file=b"Ada",
+                media_type="text/plain",
+                style="search",
+            )
+        )
+        assert async_output is expected
+        assert async_tokens.total_tokens == 3
+
+        assert (
+            asyncio.run(
+                extract_async(
+                    schema=_Person,
+                    model="openai:gpt-5",
+                    input_file=b"Ada",
+                    media_type="text/plain",
+                    style="search",
+                )
+            )
+            is expected
+        )
+
+    def test_batch_search_builds_one_agent_per_item(self, mocker):
+        _install_harness(mocker)
+        people = [_Person(name="Ada", age=36), _Person(name="Grace", age=85)]
+        agent = MagicMock()
+        agent.run = MagicMock()
+
+        async def run(inputs):
+            return SimpleNamespace(output=people.pop(0))
+
+        agent.run.side_effect = run
+        build = mocker.patch("openextract._extract._build_agent", return_value=agent)
+
+        results = extract_many(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_files=[b"a", b"b"],
+            media_type="text/plain",
+            style="search",
+        )
+
+        assert [item.name for item in results] == ["Ada", "Grace"]
+        assert build.call_count == 2
+        assert all(call.kwargs["extra_capabilities"] for call in build.call_args_list)
+
+
+class TestSessionStyles:
+    def test_injected_agent_rejects_non_direct_style(self):
+        with pytest.raises(ValueError, match="injected agent"):
+            Extractor(_Person, agent=MagicMock(), style="search")
+
+    def test_search_session_does_not_build_agent_until_extract(self, mocker):
+        _install_harness(mocker)
+        build = mocker.patch("openextract._extract.Agent", return_value=MagicMock())
+        Extractor(_Person, "openai:gpt-5", style="search")
+        build.assert_not_called()
+
+    def test_sync_search_session_extracts(self, mocker):
+        from tests.test_sessions import FakeAgent
+
+        _install_harness(mocker)
+        agent = FakeAgent([{"name": "Ada", "age": 36}, {"name": "Grace", "age": 85}])
+        mocker.patch("openextract._extract._build_agent", return_value=agent)
+        with Extractor(_Person, "openai:gpt-5", style="search") as extractor:
+            first = extractor.extract(b"Ada", media_type="text/plain")
+            second, usage = extractor.extract_with_usage(b"Grace", media_type="text/plain")
+        assert first == _Person(name="Ada", age=36)
+        assert second == _Person(name="Grace", age=85)
+        assert usage.total_tokens == 3
+
+    async def test_async_code_session_extracts(self, mocker):
+        from tests.test_sessions import FakeAgent
+
+        _install_harness(mocker)
+        agent = FakeAgent([{"name": "Ada", "age": 36}, {"name": "Grace", "age": 85}])
+        mocker.patch("openextract._extract._build_agent", return_value=agent)
+        async with AsyncExtractor(_Person, "openai:gpt-5", style="code") as extractor:
+            first = await extractor.extract(b"Ada", media_type="text/plain")
+            second, usage = await extractor.extract_with_usage(b"Grace", media_type="text/plain")
+        assert first == _Person(name="Ada", age=36)
+        assert second == _Person(name="Grace", age=85)
+        assert usage.total_tokens == 3
+
+
+class TestCliStyle:
+    def test_style_is_forwarded(self, mocker):
+        fake = _Person(name="Ada", age=36)
+        mock_extract = mocker.patch("openextract._cli.extract", return_value=fake)
+
+        assert (
+            main(
+                [
+                    "input.txt",
+                    "--schema",
+                    "tests.test_cli:_FixtureSchema",
+                    "--model",
+                    "openai:gpt-5",
+                    "--style",
+                    "search",
+                ]
+            )
+            == 0
+        )
+        assert mock_extract.call_args.kwargs["style"] == "search"

--- a/tests/test_styles.py
+++ b/tests/test_styles.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import sys
+import tempfile
+from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from pydantic_ai import BinaryContent
@@ -13,7 +15,9 @@ from openextract import (
     AsyncExtractor,
     ExtractionStyle,
     Extractor,
+    ModelError,
     ProviderNotInstalledError,
+    RetryPolicy,
     extract,
     extract_async,
     extract_many,
@@ -74,6 +78,23 @@ class TestStyleHelpers:
         assert is_binary_media_type("image/png")
         assert is_binary_media_type("application/pdf")
         assert not is_binary_media_type("text/plain")
+
+    def test_office_documents_are_binary(self):
+        assert is_binary_media_type(
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        )
+        assert is_binary_media_type(
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+        )
+        assert is_binary_media_type("application/vnd.oasis.opendocument.text")
+        assert is_binary_media_type("application/msword")
+        assert is_binary_media_type("application/vnd.ms-excel")
+        assert is_binary_media_type("application/vnd.ms-powerpoint")
+
+    def test_decode_rejects_docx_with_direct_guidance(self):
+        docx = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+        with pytest.raises(ValueError, match="Use style='direct'"):
+            decode_text_document(b"PK\x03\x04", docx, style=ExtractionStyle.SEARCH)
 
     def test_decode_rejects_pdf_and_nul_and_invalid_utf8(self):
         with pytest.raises(ValueError, match="style 'search' requires a text document"):
@@ -262,6 +283,36 @@ class TestExtractStyles:
             is expected
         )
 
+    def test_search_workspace_survives_retries(self, mocker):
+        harness, _ = _install_harness(mocker)
+        expected = _Person(name="Ada", age=36)
+        attempts: list[str] = []
+
+        def run_sync(inputs):
+            root = harness.FileSystem.call_args.kwargs["root_dir"]
+            attempts.append((root / "document.txt").read_text(encoding="utf-8"))
+            if len(attempts) == 1:
+                raise ModelError("transient", status_code=503)
+            return SimpleNamespace(output=expected)
+
+        _make_agent_mock(mocker, run_sync_side_effect=run_sync)
+
+        result = extract(
+            schema=_Person,
+            model="openai:gpt-5",
+            input_file=b"Ada is 36",
+            media_type="text/plain",
+            style="search",
+            max_retries=1,
+            retry_backoff=0,
+        )
+
+        assert result is expected
+        # The same materialized document was readable on both attempts.
+        assert attempts == ["Ada is 36", "Ada is 36"]
+        root = harness.FileSystem.call_args.kwargs["root_dir"]
+        assert not root.exists()
+
     def test_batch_search_builds_one_agent_per_item(self, mocker):
         _install_harness(mocker)
         people = [_Person(name="Ada", age=36), _Person(name="Grace", age=85)]
@@ -292,24 +343,84 @@ class TestSessionStyles:
         with pytest.raises(ValueError, match="injected agent"):
             Extractor(_Person, agent=MagicMock(), style="search")
 
-    def test_search_session_does_not_build_agent_until_extract(self, mocker):
-        _install_harness(mocker)
-        build = mocker.patch("openextract._extract.Agent", return_value=MagicMock())
-        Extractor(_Person, "openai:gpt-5", style="search")
+    def test_search_session_builds_agent_once_on_enter(self, mocker):
+        from tests.test_sessions import FakeAgent
+
+        harness, _ = _install_harness(mocker)
+        agent = FakeAgent([{"name": "Ada", "age": 36}])
+        build = mocker.patch("openextract._extract._build_agent", return_value=agent)
+        extractor = Extractor(_Person, "openai:gpt-5", style="search")
         build.assert_not_called()
+        with extractor:
+            extractor.extract(b"Ada", media_type="text/plain")
+        build.assert_called_once()
+        assert build.call_args.kwargs["extra_capabilities"] == [harness.FileSystem.return_value]
+        assert agent.enter_count == 1
+        assert agent.exit_count == 1
 
     def test_sync_search_session_extracts(self, mocker):
         from tests.test_sessions import FakeAgent
 
-        _install_harness(mocker)
+        harness, _ = _install_harness(mocker)
         agent = FakeAgent([{"name": "Ada", "age": 36}, {"name": "Grace", "age": 85}])
         mocker.patch("openextract._extract._build_agent", return_value=agent)
         with Extractor(_Person, "openai:gpt-5", style="search") as extractor:
             first = extractor.extract(b"Ada", media_type="text/plain")
             second, usage = extractor.extract_with_usage(b"Grace", media_type="text/plain")
+            workspace = harness.FileSystem.call_args.kwargs["root_dir"]
+            # Per-call documents are removed; the workspace lives until close.
+            assert workspace.exists()
+            assert list(workspace.iterdir()) == []
         assert first == _Person(name="Ada", age=36)
         assert second == _Person(name="Grace", age=85)
         assert usage.total_tokens == 3
+        assert not workspace.exists()
+
+    def test_sync_search_session_workspace_survives_retries(self, mocker):
+        from tests.test_sessions import FakeAgent
+
+        harness, _ = _install_harness(mocker)
+        documents: list[str] = []
+
+        class WorkspaceProbeAgent(FakeAgent):
+            async def run(self, inputs):
+                root = harness.FileSystem.call_args.kwargs["root_dir"]
+                filename = inputs[0].split("'")[1]
+                documents.append((root / filename).read_text(encoding="utf-8"))
+                return await super().run(inputs)
+
+        agent = WorkspaceProbeAgent(
+            [ModelError("transient", status_code=503), {"name": "Ada", "age": 36}]
+        )
+        mocker.patch("openextract._extract._build_agent", return_value=agent)
+        policy = RetryPolicy(max_retries=1, backoff=0)
+        with Extractor(_Person, "openai:gpt-5", style="search", retry_policy=policy) as session:
+            result = session.extract(b"Ada is 36", media_type="text/plain")
+        assert result == _Person(name="Ada", age=36)
+        assert agent.run_count == 2
+        # The same materialized document was readable on both attempts.
+        assert documents == ["Ada is 36", "Ada is 36"]
+
+    def test_sync_search_session_enter_failure_cleans_up(self, mocker):
+        mocker.patch.dict(sys.modules, {"pydantic_ai_harness": None})
+        client = MagicMock()
+        mocker.patch("openextract._extract.httpx.Client", return_value=client)
+        workspace_spy = mocker.spy(tempfile, "TemporaryDirectory")
+        extractor = Extractor(_Person, "openai:gpt-5", style="search")
+        with pytest.raises(ProviderNotInstalledError, match="pydantic-ai-harness"):
+            extractor.__enter__()
+        client.close.assert_called_once_with()
+        assert not Path(workspace_spy.spy_return.name).exists()
+
+    async def test_async_code_session_enter_failure_closes_client(self, mocker):
+        mocker.patch.dict(sys.modules, {"pydantic_ai_harness": None, "pydantic_monty": None})
+        client = MagicMock()
+        client.aclose = AsyncMock()
+        mocker.patch("openextract._extract.httpx.AsyncClient", return_value=client)
+        extractor = AsyncExtractor(_Person, "openai:gpt-5", style="code")
+        with pytest.raises(ProviderNotInstalledError, match="codemode"):
+            await extractor.__aenter__()
+        client.aclose.assert_awaited_once_with()
 
     async def test_async_code_session_extracts(self, mocker):
         from tests.test_sessions import FakeAgent

--- a/tests/typing/consumer.py
+++ b/tests/typing/consumer.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from openextract import (
     ExtractionInput,
     ExtractionResult,
+    ExtractionStyle,
     Usage,
     extract,
     extract_many,
@@ -61,6 +62,9 @@ with_exceptions: list[Invoice | Exception] = extract_many(
 
 # extract() -> T and the tuple usage helper stay compatible.
 single: Invoice = extract(Invoice, "openai:gpt-5", Path("/tmp/x.pdf"))
+search: Invoice = extract(
+    Invoice, "openai:gpt-5", Path("/tmp/notes.txt"), style=ExtractionStyle.SEARCH
+)
 output, usage = extract_with_usage(Invoice, "openai:gpt-5", Path("/tmp/x.pdf"))
 _assert_invoice: Invoice = output
 _assert_usage: Usage = usage


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Callers can now choose how the model inspects a document via `style` on every extract API, reusable sessions, and `--style` on the CLI.

- **`direct`** (default): pass media to the LLM in one shot (existing behavior)
- **`search`**: for text, agentic file tools (read, regex search, glob) via Pydantic AI Harness `FileSystem`
- **`code`**: for text, write Python against a workspace copy via Harness `CodeMode`

## Changes

- New `ExtractionStyle` enum (`direct` / `search` / `code`) exported from `openextract`
- `style` parameter on extract APIs, `Extractor` / `AsyncExtractor`, and CLI `--style`
- Search/code materialize UTF-8 text into a temp workspace that lives through retries
- Invalid style or non-text for search/code raises `ValueError`; missing harness extras raise `ProviderNotInstalledError`
- Docs, changelog, and `examples/advanced/extraction_styles.py`

Install `pydantic-ai-harness` for search and `pydantic-ai-harness[codemode]` for code execution. These extras are not locked in the repo because the current `exclude-newer` pin cannot resolve a harness version that matches the FileSystem/CodeMode APIs without also pulling `pydantic-ai-slim` 2.x.

## Testing

- `uv run ruff check .` / `uv run ruff format --check .`
- `uv run ty check`
- `uv run pytest --cov=openextract --cov-fail-under=100` (428 passed, 5 skipped, 100% coverage)
- `scripts/check_api_reference.py`

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ff95a-99dc-78d1-bed0-a6fb544e3e05?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ff95a-99dc-78d1-bed0-a6fb544e3e05&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

