### PR TITLE
Document unreleased features and streaming batch APIs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,4 +1,4 @@
-name: Deploy static content to Pages
+name: Deploy documentation to Pages
 
 on:
   push:
@@ -6,26 +6,24 @@ on:
     paths:
       - "docs/**"
       - ".github/workflows/deploy-docs.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "docs/**"
+      - ".github/workflows/deploy-docs.yml"
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
 
 jobs:
-  # Single deploy job since we're just deploying
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -35,11 +33,25 @@ jobs:
           persist-credentials: false
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b  # v5.0.0
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697  # v1.0.13
+        with:
+          source: ./docs
+          destination: ./_site
       - name: Upload artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
         with:
-          # Upload docs directory
-          path: './docs'
+          path: ./_site
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ timing when that is known.
   completion order without waiting for the full batch.
 - Streaming-batch example and docs comparing `iter_extract_many_async`
   (completion order) with `extract_many` (input order).
+- GitHub Pages now builds a documentation site: user [guide](docs/guide.md),
+  [agent contract](docs/agents.md), rendered API/CLI/provider pages, and
+  [`llms.txt`](docs/llms.txt).
 
 ### Changed
 - Split the internal extraction implementation into focused modules (`_types`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ timing when that is known.
   and source-distribution install smoke tests.
 - `iter_extract_many_async()` streams `(input_index, result)` pairs in
   completion order without waiting for the full batch.
+- Streaming-batch example and docs comparing `iter_extract_many_async`
+  (completion order) with `extract_many` (input order).
 
 ### Changed
 - Split the internal extraction implementation into focused modules (`_types`,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,14 @@ OPENEXTRACT_LIVE_SMOKE=1 uv run pytest -m integration tests/test_live_smoke.py -
 
 See [docs/live-smoke.md](docs/live-smoke.md).
 
+## Documentation site
+
+Markdown under `docs/` is built with Jekyll and deployed by
+[`.github/workflows/deploy-docs.yml`](.github/workflows/deploy-docs.yml).
+User/agent how-tos are `docs/guide.md` and `docs/agents.md`. `docs/llms.txt`
+is copied through as a static file for coding agents. The landing page is
+`docs/index.html`. Do not add `docs/.nojekyll`; the workflow uploads `_site`.
+
 ## Release checklist (maintainers)
 
 Use this before cutting a release (a version bump on `main` publishes only after

--- a/README.md
+++ b/README.md
@@ -300,6 +300,35 @@ Each `ExtractionResult` carries `output`, `usage`, `attempts`, `duration`,
 `model`, `media_type`, and a sanitized `source` (never raw media, credentials,
 or query strings). The async sibling is `extract_many_with_results_async`.
 
+### Streaming batch
+
+`extract_many` waits for every item and returns a list in **input order**.
+`iter_extract_many_async` yields `(input_index, result)` in **completion
+order**, so you can start processing before the last item finishes. Inputs are
+consumed lazily and at most `max_concurrency` items are in flight.
+
+```python
+import asyncio
+from openextract import iter_extract_many_async
+
+async def main() -> None:
+    async for index, result in iter_extract_many_async(
+        schema=PdfInfo,
+        model="xai:grok-4.3",
+        input_files=[Path("./reports/q3.pdf"), Path("./reports/q4.pdf")],
+        return_exceptions=True,
+    ):
+        if isinstance(result, Exception):
+            print(f"{index} failed: {result}")
+        else:
+            print(index, result.summary)
+
+asyncio.run(main())
+```
+
+Runnable comparison of input order vs completion order:
+[`examples/batch/stream_batch_extract.py`](examples/batch/stream_batch_extract.py).
+
 ### Choosing a model
 
 `model` follows the `pydantic-ai` provider prefix convention:
@@ -405,7 +434,7 @@ Troubleshooting: [docs/troubleshooting.md](docs/troubleshooting.md).
 
 ## Examples
 
-Runnable scripts live in [`examples/`](examples/), grouped by use case (local files, bytes, URLs, images, batch, async, retries, CLI, and more). See [examples/README.md](examples/README.md) for the full table.
+Runnable scripts live in [`examples/`](examples/), grouped by use case (local files, bytes, URLs, images, batch, streaming batch, async, retries, CLI, and more). See [examples/README.md](examples/README.md) for the full table.
 
 ```bash
 # Run all fixture-based examples (uses OpenAI, Anthropic, and xAI — see examples/README.md)
@@ -459,9 +488,10 @@ build.
 ## Public API stability
 
 `openextract.__all__` is the public Python API surface. Modules and helpers whose
-names start with `_`, including `openextract._extract` and `openextract._cli`, are
-internal implementation details. The CLI command is also user-facing and follows
-the compatibility notes below even though it is not exported from `__all__`.
+names start with `_`, including `openextract._extract`, `openextract._batch`,
+`openextract._session`, and `openextract._cli`, are internal implementation
+details. The CLI command is also user-facing and follows the compatibility notes
+below even though it is not exported from `__all__`.
 
 | API | Status for 1.0 | Notes |
 | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -12,13 +12,15 @@
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![Downloads](https://img.shields.io/pypi/dm/openextract.svg?color=blue)](https://pypi.org/project/openextract/)
 
-[Documentation](https://mellow-artificial-intelligence.github.io/openextract/) &middot; [PyPI](https://pypi.org/project/openextract/) &middot; [Changelog](CHANGELOG.md) &middot; [Issues](https://github.com/Mellow-Artificial-Intelligence/openextract/issues)
+[Documentation](https://mellow-artificial-intelligence.github.io/openextract/guide.html) &middot; [For agents](https://mellow-artificial-intelligence.github.io/openextract/agents.html) &middot; [PyPI](https://pypi.org/project/openextract/) &middot; [Changelog](CHANGELOG.md) &middot; [Issues](https://github.com/Mellow-Artificial-Intelligence/openextract/issues)
 
 </div>
 
 ---
 
 `openextract` turns any document, image, audio, or video file into a typed Pydantic model in a single function call. Point it at a local path or a URL, pass a schema, and get back a validated object you can use directly in your code.
+
+The [guide](https://mellow-artificial-intelligence.github.io/openextract/guide.html) is the how-to. Coding agents should start at [For agents](https://mellow-artificial-intelligence.github.io/openextract/agents.html) or [llms.txt](https://mellow-artificial-intelligence.github.io/openextract/llms.txt).
 
 ## Features
 
@@ -481,9 +483,10 @@ All `openextract` exceptions inherit from `ExtractionError`, so you can catch it
 ## API reference
 
 The canonical public API reference lives in
-[docs/api-reference.md](docs/api-reference.md). CI verifies every documented
-function signature against the installed package so signature drift fails the
-build.
+[docs/api-reference.md](docs/api-reference.md) (also on the
+[docs site](https://mellow-artificial-intelligence.github.io/openextract/api-reference.html)).
+CI verifies every documented function signature against the installed package so
+signature drift fails the build.
 
 ## Public API stability
 

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Not found
+permalink: /404.html
+---
+
+# Page not found
+
+That URL is not a documentation page.
+
+- [Guide](guide.md) — how to use openextract
+- [For agents](agents.md) — integration contract
+- [API reference](api-reference.md)
+- [Home]({{ '/' | relative_url }})

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,18 +1,39 @@
-title: openextract Documentation
+title: openextract
 description: Extract structured data from documents, images, audio, and video using LLMs
 baseurl: "/openextract"
 url: "https://mellow-artificial-intelligence.github.io"
 
 markdown: kramdown
 highlighter: rouge
-theme: minima
+kramdown:
+  input: GFM
+  syntax_highlighter: rouge
+  syntax_highlighter_opts:
+    css_class: highlight
 
 plugins:
-  - jekyll-feed
   - jekyll-sitemap
+  - jekyll-relative-links
+
+relative_links:
+  enabled: true
+  collections: true
+
+include:
+  - llms.txt
 
 exclude:
   - Gemfile
   - Gemfile.lock
   - node_modules
   - vendor
+
+defaults:
+  - scope:
+      path: "index.html"
+    values:
+      layout: null
+  - scope:
+      path: ""
+    values:
+      layout: page

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,5 +1,5 @@
 title: openextract Documentation
-description: Open-source framework that extracts structured data from PDFs
+description: Extract structured data from documents, images, audio, and video using LLMs
 baseurl: "/openextract"
 url: "https://mellow-artificial-intelligence.github.io"
 

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -1,0 +1,10 @@
+<footer class="docs-footer">
+  <div class="docs-footer-inner">
+    <span>&copy; 2026 openextract. MIT License.</span>
+    <span>
+      <a href="{{ '/guide.html' | relative_url }}">Guide</a>
+      <a href="{{ '/agents.html' | relative_url }}">Agents</a>
+      <a href="https://github.com/Mellow-Artificial-Intelligence/openextract">GitHub</a>
+    </span>
+  </div>
+</footer>

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -1,0 +1,17 @@
+{% assign url = page.url | default: '/' %}
+<header class="docs-header">
+  <div class="docs-header-inner">
+    <a class="docs-brand" href="{{ '/' | relative_url }}">
+      <span class="docs-mark">OE</span>
+      <span class="docs-brand-name">openextract</span>
+    </a>
+    <nav class="docs-nav" aria-label="Primary">
+      <a href="{{ '/guide.html' | relative_url }}"{% if url == '/guide.html' %} class="is-active"{% endif %}>Guide</a>
+      <a href="{{ '/agents.html' | relative_url }}"{% if url == '/agents.html' %} class="is-active"{% endif %}>Agents</a>
+      <a href="{{ '/api-reference.html' | relative_url }}"{% if url == '/api-reference.html' %} class="is-active"{% endif %}>API</a>
+      <a href="{{ '/cli.html' | relative_url }}"{% if url == '/cli.html' %} class="is-active"{% endif %}>CLI</a>
+      <a href="https://github.com/Mellow-Artificial-Intelligence/openextract">GitHub</a>
+      <a href="https://pypi.org/project/openextract/">PyPI</a>
+    </nav>
+  </div>
+</header>

--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -1,0 +1,17 @@
+{% assign url = page.url | default: '/' %}
+<nav class="docs-side" aria-label="Documentation">
+  <p>Use</p>
+  <a href="{{ '/guide.html' | relative_url }}"{% if url == '/guide.html' %} class="is-active"{% endif %}>Guide</a>
+  <a href="{{ '/agents.html' | relative_url }}"{% if url == '/agents.html' %} class="is-active"{% endif %}>For agents</a>
+  <a href="{{ '/api-reference.html' | relative_url }}"{% if url == '/api-reference.html' %} class="is-active"{% endif %}>API reference</a>
+  <a href="{{ '/cli.html' | relative_url }}"{% if url == '/cli.html' %} class="is-active"{% endif %}>CLI contracts</a>
+  <a href="{{ '/providers.html' | relative_url }}"{% if url == '/providers.html' %} class="is-active"{% endif %}>Providers</a>
+  <a href="{{ '/troubleshooting.html' | relative_url }}"{% if url == '/troubleshooting.html' %} class="is-active"{% endif %}>Troubleshooting</a>
+  <p>Maintain</p>
+  <a href="{{ '/extractbench.html' | relative_url }}"{% if url == '/extractbench.html' %} class="is-active"{% endif %}>ExtractBench</a>
+  <a href="{{ '/live-smoke.html' | relative_url }}"{% if url == '/live-smoke.html' %} class="is-active"{% endif %}>Live smoke</a>
+  <a href="{{ '/benchmarking.html' | relative_url }}"{% if url == '/benchmarking.html' %} class="is-active"{% endif %}>Benchmarking</a>
+  <a href="{{ '/design/input-size-limits.html' | relative_url }}"{% if url == '/design/input-size-limits.html' %} class="is-active"{% endif %}>Input size limits</a>
+  <p>Machine</p>
+  <a href="{{ '/llms.txt' | relative_url }}">llms.txt</a>
+</nav>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>{{ page.title }} · openextract</title>
+  <meta name="description" content="{{ page.description | default: site.description }}" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="{{ '/assets/docs.css' | relative_url }}" />
+</head>
+<body class="docs-body">
+  {% include nav.html %}
+  <div class="docs-shell">
+    {% include sidenav.html %}
+    <article class="prose">
+      {{ content }}
+    </article>
+  </div>
+  {% include footer.html %}
+</body>
+</html>

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,116 @@
+---
+layout: page
+title: For agents
+description: Contract for coding agents generating or editing openextract integrations.
+---
+
+# For agents
+
+This page is the integration contract for coding agents, IDE tools, and generated examples. Humans should start at the [Guide](guide.md). Machine-readable index: [llms.txt](llms.txt).
+
+## Public surface
+
+Import only names in `openextract.__all__`. Modules whose names start with `_` (`openextract._extract`, `_batch`, `_session`, `_cli`, …) are private and may change without deprecation.
+
+Stable enough to generate against: `extract`, `extract_async`, `extract_with_usage`, `extract_with_usage_async`, `Usage`, and the exception types. Provisional (still public, may evolve before 1.0): sessions, batch helpers, `ExtractionInput` / `ExtractionResult`, `ExtractionStyle`, CLI flags.
+
+Canonical signatures: [API reference](api-reference.md). CI fails if those headings drift from the installed callables.
+
+## Minimal call
+
+```python
+from pydantic import BaseModel
+from openextract import extract
+
+
+class Info(BaseModel):
+    summary: str
+
+
+result = extract(schema=Info, model="openai:gpt-5", input_file="doc.pdf")
+```
+
+Always define a real `pydantic.BaseModel` subclass. Do not ask the library for free-form JSON.
+
+## Which API to generate
+
+| Situation | Use |
+| --- | --- |
+| One input, sync code | `extract` |
+| One input, async code | `extract_async` |
+| Need token counts | `extract_with_usage` / `_async` |
+| Same schema/model many times | `Extractor` / `AsyncExtractor` |
+| Many inputs, want a list | `extract_many` (sync, **not** from a running loop) or `extract_many_async` |
+| Many inputs, stream as done | `iter_extract_many_async` — yields `(input_index, result)` in **completion order** |
+| Per-item usage / timing | `extract_many_with_results*` + `total_usage` |
+| Shell / CI | `openextract` CLI; parse **stdout** only |
+
+## Input rules (common bugs)
+
+- `bytes` and file-like objects **require** `media_type`. Missing it is `TypeError`, not an extraction error.
+- Paths and URLs may omit `media_type`; it is guessed or taken from `Content-Type`.
+- Mix paths, bytes, and URLs in one batch via `ExtractionInput` with per-item `media_type`.
+- Default size cap is 50 MiB (`InputTooLargeError`). Do not read the file yourself “to be safe” unless the caller needs a smaller cap — pass `max_input_bytes`.
+- The library does **not** load `.env`. Set credentials in the process environment, or load dotenv in the app/CLI layer.
+- URL fetches block private/loopback hosts unless `OPENEXTRACT_ALLOW_PRIVATE_URLS` is set.
+
+## Styles
+
+Default `style='direct'`. `search` and `code` are **text-only** (`text/*`, JSON, XML, YAML). Do not emit `style='search'` for PDFs, images, audio, or video. Those styles need `pydantic-ai-harness` / `pydantic-ai-harness[codemode]` and raise `ProviderNotInstalledError` if the extra is missing. Do not combine `search`/`code` with an injected `agent=`.
+
+## Errors to catch
+
+Catch `ExtractionError` as the fallback. Prefer the specific subclass:
+
+- `UrlFetchError` — fetch/SSRF
+- `InputTooLargeError` — cap
+- `SchemaValidationError` — output mismatch (tighten `instructions` / schema; this is not retried)
+- `ModelError` — inspect `.retryable` before retrying yourself; the library already retries when `max_retries > 0`
+- `ProviderNotInstalledError` — print the exception; it includes the install command
+
+Do not catch `Exception` and retry. Do not retry `SchemaValidationError` unless the user asked for it.
+
+Invalid `max_retries`, `retry_backoff`, `retry_max_backoff`, or `max_concurrency` raise **`ValueError` before any model call**.
+
+## Do not
+
+- Import or patch `openextract._*` in application code.
+- Call `extract_many` / `extract_many_with_results` from a running asyncio loop.
+- Assume `extract_many` yields completion order — it returns **input order**. Completion order is only `iter_extract_many_async`.
+- Treat CLI stderr as the payload. Exit `7` still has the batch JSON on stdout.
+- Hard-code Chat Completions for OpenAI. `openai:` uses the Responses API; opt into `openai-chat:` only when required.
+- Claim provider media support that the [capability matrix](providers.md) marks expected/unknown.
+- Add provider SDKs as direct dependencies of the caller if `openextract[extra]` already pulls them.
+
+## CLI if you shell out
+
+```bash
+openextract INPUT --schema package.mod:Class --model openai:gpt-5
+```
+
+| Exit | Meaning |
+| --- | --- |
+| `0` | Success |
+| `1` | Usage / bad `--schema` / invalid options |
+| `2`–`6` | `UrlFetchError` … `ProviderNotInstalledError` |
+| `7` | Partial batch failure (`--continue-on-error`) |
+
+`--schema` is `module:ClassName`. For stdin, pass `-` and `--media-type`. Full contract: [CLI](cli.md).
+
+## Tests without live providers
+
+Prefer `pydantic_ai.models.test.TestModel` (or inject an `Agent`) so examples and unit tests do not need API keys:
+
+```python
+from pydantic_ai.models.test import TestModel
+from openextract import extract
+
+model = TestModel(custom_output_args={"summary": "ok"})
+extract(schema=Info, model=model, input_file=b"hello", media_type="text/plain")
+```
+
+Repo examples that must run without credentials follow this pattern (`examples/advanced/reusable_sessions.py`, `examples/batch/stream_batch_extract.py`).
+
+## Install extras (prefix → extra)
+
+`openai`, `openai-chat`, `openai-responses`, `cerebras`, `ollama` → `openextract[openai]`. Also: `anthropic`, `google-gla` / `google-vertex` → `google`, `bedrock`, `cohere`, `groq`, `huggingface`, `mistral`, `openrouter`, `xai`. Unknown prefixes suggest `openextract[all]`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -9,6 +9,8 @@ This is the canonical reference for the public Python API. CI compares every
 function heading below with the installed callable signature; update this page
 in the same change as any public signature.
 
+How-to: [Guide](guide.md). Integration contract for generated code: [For agents](agents.md).
+
 ## Extraction
 
 ### `Extractor(schema, model=None, instructions=None, *, style='direct', agent=None, model_settings=None, timeout=None, instrument=False, retry_policy=None, max_input_bytes=None, url_timeout=None)`

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -41,6 +41,14 @@ Frozen session retry configuration. Only transient `ModelError` failures are
 retried. The backoff and bounded provider `Retry-After` behavior match the
 one-shot function arguments.
 
+### ExtractionStyle
+
+`direct` (default) sends resolved media to the model in one shot. `search` and
+`code` are text-only agentic styles powered by
+[Pydantic AI Harness](https://pydantic.dev/docs/ai/harness/). Pass the enum
+(`ExtractionStyle.SEARCH`) or the string (`"search"`). Non-text inputs and a
+missing harness extra fail before the model call.
+
 ### `extract(schema, model, input_file, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
 Extract one input synchronously and return an instance of `schema`.
@@ -73,14 +81,33 @@ and per-item retry behavior.
 
 ### `iter_extract_many_async(schema, model, input_files, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
-Return an async iterator of `(input_index, result)` pairs in completion order.
-Inputs are consumed lazily, at most `max_concurrency` items are scheduled, and
-results are available before the complete batch finishes. Simultaneous
-completions are yielded in input-index order.
+Return an async iterator of `(input_index, result)` pairs in **completion
+order**. Inputs are consumed lazily, at most `max_concurrency` items are
+scheduled, and results are available before the complete batch finishes.
+Simultaneous completions are yielded in input-index order.
+
+This is the streaming counterpart to `extract_many_async`, which waits for every
+item and returns a list in **input order**. Keep the original `input_files`
+sequence (or a name on `ExtractionInput`) if you need to map `input_index` back
+to a path.
 
 With `return_exceptions=False`, the first failure cancels and awaits outstanding
 work before being raised. With `return_exceptions=True`, item exceptions are
 yielded in the result position and streaming continues.
+
+```python
+async for index, result in iter_extract_many_async(
+    schema=PdfInfo,
+    model="openai:gpt-5",
+    input_files=paths,
+    return_exceptions=True,
+    max_concurrency=5,
+):
+    if isinstance(result, Exception):
+        print(f"{index} failed: {result}")
+    else:
+        print(index, result.summary)
+```
 
 ### `extract_many_with_results(schema, model, input_files, instructions=None, *, style='direct', media_type=None, max_input_bytes=None, max_concurrency=5, return_exceptions=False, max_retries=0, retry_backoff=1.0, retry_max_backoff=60.0)`
 
@@ -102,6 +129,19 @@ result ordering, and per-item retry behavior.
 Sum token usage across batch extraction results, for example the list returned
 by `extract_many_with_results` or `extract_many_with_results_async`. Returns a
 single [`Usage`](#usage) whose fields are the totals of the successful items.
+
+## Choosing a batch API
+
+| API | Returns | Order | When to use |
+| --- | --- | --- | --- |
+| `extract_many` / `extract_many_async` | `list[T]` (or exceptions in place) | Input order | You want the full batch before continuing. |
+| `iter_extract_many_async` | `(input_index, result)` as items finish | Completion order | Large or generator inputs; start work before the last item completes. |
+| `extract_many_with_results` / `_async` | `list[ExtractionResult[T]]` | Input order | Per-item usage, attempts, duration, and sanitized source labels. |
+
+`extract_many` and `extract_many_with_results` raise `RuntimeError` from a
+running event loop; use the `_async` siblings or the iterator instead. See
+[`examples/batch/stream_batch_extract.py`](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/examples/batch/stream_batch_extract.py)
+for a side-by-side run.
 
 ## Input and result contracts
 

--- a/docs/assets/docs.css
+++ b/docs/assets/docs.css
@@ -1,0 +1,314 @@
+:root {
+  --bg: #fafafa;
+  --fg: #111;
+  --muted: rgba(0, 0, 0, 0.6);
+  --faint: rgba(0, 0, 0, 0.4);
+  --line: rgba(0, 0, 0, 0.1);
+}
+
+html { scroll-behavior: smooth; }
+
+body.docs-body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: Inter, system-ui, sans-serif;
+  min-height: 100vh;
+  margin: 0;
+}
+
+body.docs-body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  background-image:
+    linear-gradient(to right, rgba(0,0,0,0.03) 1px, transparent 1px),
+    linear-gradient(to bottom, rgba(0,0,0,0.03) 1px, transparent 1px);
+  background-size: 60px 60px;
+  pointer-events: none;
+}
+
+.docs-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(250, 250, 250, 0.8);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+
+.docs-header-inner,
+.docs-footer-inner,
+.docs-shell {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.docs-header-inner {
+  height: 3.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.docs-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.docs-mark {
+  width: 2rem;
+  height: 2rem;
+  background: #000;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.7rem;
+  font-weight: 700;
+}
+
+.docs-brand-name {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.875rem;
+  color: var(--muted);
+}
+
+.docs-nav {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.docs-nav a {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  color: var(--faint);
+  text-decoration: none;
+}
+
+.docs-nav a:hover,
+.docs-nav a.is-active {
+  color: #000;
+}
+
+.docs-shell {
+  display: grid;
+  grid-template-columns: 13rem minmax(0, 1fr);
+  gap: 2.5rem;
+  padding-top: 2.5rem;
+  padding-bottom: 4rem;
+}
+
+.docs-side {
+  position: sticky;
+  top: 4.5rem;
+  align-self: start;
+}
+
+.docs-side p {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 1.25rem 0 0.4rem;
+}
+
+.docs-side p:first-child { margin-top: 0; }
+
+.docs-side a {
+  display: block;
+  font-size: 0.875rem;
+  color: var(--muted);
+  text-decoration: none;
+  padding: 0.2rem 0;
+}
+
+.docs-side a:hover,
+.docs-side a.is-active {
+  color: #000;
+}
+
+.prose {
+  max-width: 48rem;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  color: rgba(0, 0, 0, 0.78);
+}
+
+.prose > *:first-child { margin-top: 0; }
+
+.prose h1 {
+  font-size: 2rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  color: #000;
+  margin: 0 0 1rem;
+  line-height: 1.2;
+}
+
+.prose h2 {
+  font-size: 1.25rem;
+  font-weight: 650;
+  color: #000;
+  margin: 2.25rem 0 0.75rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--line);
+}
+
+.prose h3 {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: #111;
+  margin: 1.5rem 0 0.5rem;
+}
+
+.prose h4 {
+  font-size: 0.95rem;
+  font-weight: 600;
+  margin: 1.25rem 0 0.4rem;
+}
+
+.prose p, .prose ul, .prose ol, .prose pre, .prose table, .prose blockquote {
+  margin: 0 0 1rem;
+}
+
+.prose ul, .prose ol { padding-left: 1.25rem; }
+.prose li { margin: 0.25rem 0; }
+.prose li > ul, .prose li > ol { margin: 0.25rem 0 0.5rem; }
+
+.prose a { color: #000; }
+.prose a:hover { text-decoration-thickness: 2px; }
+
+.prose code {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.82em;
+  background: rgba(0, 0, 0, 0.05);
+  padding: 0.1em 0.35em;
+}
+
+.prose pre, .prose .highlight {
+  background: #fff;
+  border: 1px solid var(--line);
+  overflow-x: auto;
+}
+
+.prose pre {
+  padding: 1rem 1.1rem;
+  font-size: 0.8rem;
+  line-height: 1.55;
+  font-family: "JetBrains Mono", monospace;
+}
+
+.prose .highlight { margin: 0 0 1rem; }
+.prose .highlight pre {
+  margin: 0;
+  border: 0;
+  background: transparent;
+}
+
+.prose pre code {
+  background: transparent;
+  padding: 0;
+  font-size: inherit;
+}
+
+.prose table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.85rem;
+  display: block;
+  overflow-x: auto;
+}
+
+.prose th, .prose td {
+  border: 1px solid var(--line);
+  padding: 0.45rem 0.65rem;
+  text-align: left;
+  vertical-align: top;
+  background: #fff;
+}
+
+.prose th {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.72rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--faint);
+  background: #fff;
+}
+
+.prose blockquote {
+  border-left: 2px solid #000;
+  padding: 0.15rem 0 0.15rem 1rem;
+  color: var(--muted);
+}
+
+.prose hr {
+  border: 0;
+  border-top: 1px solid var(--line);
+  margin: 2rem 0;
+}
+
+.docs-footer {
+  border-top: 1px solid rgba(0, 0, 0, 0.05);
+  padding: 1.5rem 0;
+}
+
+.docs-footer-inner {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-family: "JetBrains Mono", monospace;
+  font-size: 0.75rem;
+  color: var(--faint);
+}
+
+.docs-footer a {
+  color: var(--faint);
+  text-decoration: none;
+  margin-left: 1.25rem;
+}
+
+.docs-footer a:hover { color: var(--muted); }
+
+@media (max-width: 800px) {
+  .docs-brand-name { display: none; }
+  .docs-shell {
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    padding-top: 1.5rem;
+  }
+  .docs-side {
+    position: static;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 1rem;
+    border-bottom: 1px solid var(--line);
+    padding-bottom: 1rem;
+  }
+  .docs-side p {
+    flex-basis: 100%;
+    margin: 0.5rem 0 0;
+  }
+  .docs-side p:first-child { margin-top: 0; }
+  .docs-side a { padding: 0; }
+}
+
+.highlight .k, .highlight .kd, .highlight .kn { color: rgba(0,0,0,0.45); }
+.highlight .s, .highlight .s1, .highlight .s2, .highlight .mi { color: #059669; }
+.highlight .n, .highlight .nb, .highlight .nc, .highlight .nf { color: rgba(0,0,0,0.8); }
+.highlight .c, .highlight .c1 { color: rgba(0,0,0,0.4); }
+.highlight .o, .highlight .p { color: rgba(0,0,0,0.45); }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -157,4 +157,5 @@ exit `6` (`ProviderNotInstalledError`). Non-text inputs raise `ValueError`
 ## Related docs
 
 - [Troubleshooting](troubleshooting.md)
+- [API reference](api-reference.md)
 - [URL security model](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/SECURITY.md#url-input-security-model)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -156,6 +156,8 @@ exit `6` (`ProviderNotInstalledError`). Non-text inputs raise `ValueError`
 
 ## Related docs
 
+- [Guide](guide.md)
+- [For agents](agents.md)
 - [Troubleshooting](troubleshooting.md)
 - [API reference](api-reference.md)
 - [URL security model](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/SECURITY.md#url-input-security-model)

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,227 @@
+---
+layout: page
+title: Guide
+description: How to extract structured data with openextract — install, inputs, styles, sessions, batch, errors, and CLI.
+---
+
+# Guide
+
+`openextract` turns a document, image, audio file, or video into a **validated Pydantic model**. You bring a schema, a model identifier, and media; you get a typed object back.
+
+This page is the how-to. Use [API reference](api-reference.md) for signatures, [For agents](agents.md) if you are generating code against the library, and [llms.txt](llms.txt) for a machine-readable contract.
+
+## Install
+
+```bash
+uv add openextract
+# or
+pip install openextract
+```
+
+The base package does **not** install provider SDKs. Add the extra for the model you call:
+
+```bash
+pip install 'openextract[openai]'
+pip install 'openextract[anthropic]'
+pip install 'openextract[xai]'
+pip install 'openextract[all]'
+```
+
+Requires **Python 3.12+**. Missing extras raise `ProviderNotInstalledError` with a `pip install 'openextract[...]'` hint.
+
+## First extraction
+
+```python
+from pydantic import BaseModel
+from openextract import extract
+
+
+class Invoice(BaseModel):
+    vendor: str
+    total: float
+    currency: str
+
+
+invoice = extract(
+    schema=Invoice,
+    model="openai:gpt-5",
+    input_file="./invoices/acme.pdf",
+    instructions="Extract vendor, total, and currency.",
+)
+
+print(invoice.vendor, invoice.total)
+```
+
+`invoice` is an `Invoice` instance — not a dict, not a JSON string.
+
+Set provider credentials in the environment (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `XAI_API_KEY`, …). The **CLI and bundled examples** load `.env`; the **Python library does not**.
+
+## Inputs
+
+Every extract API accepts:
+
+| Form | Notes |
+| --- | --- |
+| Path string or `pathlib.Path` | MIME type is guessed from the name; override with `media_type`. |
+| `http://` or `https://` URL | Fetched with SSRF host checks. See [SECURITY.md](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/SECURITY.md#url-input-security-model). |
+| `bytes` or a binary file-like object | **`media_type` is required.** |
+| `ExtractionInput` | Per-item `media_type` and optional safe `name` for batch diagnostics. |
+
+```python
+from pathlib import Path
+from openextract import ExtractionInput, extract
+
+extract(schema=Invoice, model="openai:gpt-5", input_file=Path("bill.pdf"))
+extract(schema=Invoice, model="openai:gpt-5", input_file=pdf_bytes, media_type="application/pdf")
+extract(
+    schema=Invoice,
+    model="openai:gpt-5",
+    input_file=ExtractionInput(pdf_bytes, media_type="application/pdf", name="bill.pdf"),
+)
+```
+
+Each input is capped at **50 MiB** (`52428800` bytes) before a model call. Override with `max_input_bytes` or `OPENEXTRACT_MAX_INPUT_BYTES`. Oversized inputs raise `InputTooLargeError`.
+
+Private/loopback URL hosts are refused unless `OPENEXTRACT_ALLOW_PRIVATE_URLS` is set. Tune `OPENEXTRACT_URL_TIMEOUT` (default `30`) and `OPENEXTRACT_MAX_REDIRECTS` (default `10`).
+
+## Extraction styles
+
+`style` selects how the model inspects the media:
+
+| Style | Behavior | Requirements |
+| --- | --- | --- |
+| `direct` (default) | Send the resolved media to the model in one shot. | Any supported modality. |
+| `search` | Grep/read a **text** document with sandboxed file tools. | `pydantic-ai-harness`; UTF-8 text only. |
+| `code` | Write Python against a workspace copy of the **text**. | `pydantic-ai-harness[codemode]`; UTF-8 text only. |
+
+```python
+extract(schema=Invoice, model="openai:gpt-5", input_file="notes.txt", style="search")
+```
+
+PDFs, Office files, images, audio, and video stay on `direct`. The CLI flag is `--style`. Written against `pydantic-ai-harness` 0.18.x.
+
+## Sessions
+
+For repeated calls with the same schema and model, use `Extractor` / `AsyncExtractor`. One agent and HTTP client are built on enter and closed on exit.
+
+```python
+from openextract import Extractor, RetryPolicy
+
+with Extractor(
+    Invoice,
+    "openai:gpt-5",
+    instructions="Extract vendor, total, and currency.",
+    retry_policy=RetryPolicy(max_retries=3),
+) as extractor:
+    q3 = extractor.extract("./invoices/q3.pdf")
+    q4, usage = extractor.extract_with_usage("./invoices/q4.pdf")
+```
+
+`Extractor` is thread-bound and not thread-safe. `AsyncExtractor` is bound to one event loop; concurrent awaits on that loop are fine. Pass a configured `pydantic_ai.models.Model` as `model=`, or a fully configured `Agent` as `agent=` (mutually exclusive with `model=`; not combinable with `search`/`code`).
+
+## Retries and usage
+
+`max_retries` defaults to `0`. Only **transient** `ModelError` values retry (timeouts, rate limits, supported 5xx). Auth and invalid-request failures fail immediately. Backoff is exponential with jitter, capped by `retry_max_backoff` (default 60s). A bounded provider `Retry-After` wins when present.
+
+The input is resolved **once**; retries reuse the same bytes, prompt, and agent.
+
+```python
+from openextract import extract_with_usage
+
+invoice, usage = extract_with_usage(
+    schema=Invoice,
+    model="openai:gpt-5",
+    input_file="bill.pdf",
+    max_retries=3,
+)
+print(usage.input_tokens, usage.output_tokens, usage.total_tokens)
+```
+
+## Batch
+
+| API | Returns | Order | Use when |
+| --- | --- | --- | --- |
+| `extract_many` / `extract_many_async` | `list[T]` | Input order | You want the full batch. |
+| `iter_extract_many_async` | `(index, result)` as items finish | Completion order | Large/generator inputs; start work early. |
+| `extract_many_with_results*` | `list[ExtractionResult[T]]` | Input order | Per-item usage, attempts, duration, sanitized source. |
+
+```python
+from openextract import extract_many, iter_extract_many_async, total_usage
+
+results = extract_many(
+    schema=Invoice,
+    model="openai:gpt-5",
+    input_files=["a.pdf", "b.pdf"],
+    max_concurrency=5,
+    return_exceptions=True,
+)
+
+async for index, item in iter_extract_many_async(
+    schema=Invoice,
+    model="openai:gpt-5",
+    input_files=paths,
+    return_exceptions=True,
+):
+    ...
+```
+
+`extract_many` **cannot** run inside an active event loop (`RuntimeError`); use `extract_many_async` or the iterator. Default fail-fast cancels outstanding work. `return_exceptions=True` keeps going and puts errors in the result position. `total_usage(results)` sums successful `ExtractionResult` usage.
+
+See [`examples/batch/stream_batch_extract.py`](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/examples/batch/stream_batch_extract.py).
+
+## Errors
+
+All public exceptions subclass `ExtractionError`.
+
+| Exception | Typical cause | CLI exit |
+| --- | --- | --- |
+| `UrlFetchError` | Network, HTTP, or SSRF refusal | `2` |
+| `SchemaValidationError` | Model output did not match the schema | `3` |
+| `ModelError` | Provider/model API failure (`provider`, `status_code`, `retryable`, `retry_after`) | `4` |
+| `InputTooLargeError` | Over the byte cap | `5` |
+| `ProviderNotInstalledError` | Missing extra or harness package | `6` |
+| `ValueError` | Bad options (`max_retries`, `max_concurrency`, missing `media_type` for bytes) | `1` |
+
+```python
+from openextract import ExtractionError, ModelError, UrlFetchError, extract
+
+try:
+    extract(schema=Invoice, model="openai:gpt-5", input_file=url)
+except UrlFetchError:
+    ...
+except ModelError as exc:
+    print(exc.provider, exc.status_code, exc.retryable, exc.retry_after)
+except ExtractionError:
+    ...
+```
+
+## CLI
+
+```bash
+openextract ./bill.pdf \
+  --schema mypkg.schemas:Invoice \
+  --model openai:gpt-5 \
+  --instructions "Extract vendor, total, and currency."
+```
+
+- Success goes to **stdout**; errors to **stderr**.
+- `--schema` is `module:ClassName` on `PYTHONPATH`.
+- Batch: pass multiple paths. `--continue-on-error` emits per-item errors inline and exits `7` if any failed.
+- `--usage` is single-input only.
+- `--style`, `--max-retries`, `--max-input-bytes` match the Python API.
+
+Full stdout/stderr/exit-code contract: [CLI](cli.md).
+
+## Models
+
+`model` uses the `pydantic-ai` prefix convention (`openai:gpt-5`, `anthropic:claude-sonnet-4`, `xai:grok-4.3`, `ollama:llama3`, …). `openai:` routes through the **Responses API** by default; use `openai-chat:` for Chat Completions.
+
+Capability matrix and credentials: [Providers](providers.md).
+
+## What to read next
+
+- [For agents](agents.md) — public surface, do-nots, and a decision tree for generated code.
+- [API reference](api-reference.md) — every public signature (CI-checked).
+- [Troubleshooting](troubleshooting.md) — extras, URLs, retries, batch choice.
+- [Examples](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/examples/README.md) — runnable scripts.
+- [Changelog](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md)

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,3 +1,7 @@
+---
+layout: null
+title: openextract
+---
 <!DOCTYPE html>
 <html lang="en" class="scroll-smooth">
 <head>
@@ -70,7 +74,7 @@
     <!-- Navigation -->
     <header class="fixed top-0 w-full z-50 bg-[#fafafa]/80 backdrop-blur-lg border-b border-black/5">
       <div class="max-w-5xl mx-auto px-4 sm:px-6 h-14 flex items-center justify-between">
-        <a href="#" class="flex items-center gap-2">
+        <a href="{{ '/' | relative_url }}" class="flex items-center gap-2">
           <div class="w-8 h-8 bg-black flex items-center justify-center">
             <span class="text-white font-mono font-bold text-xs">OE</span>
           </div>
@@ -78,7 +82,9 @@
         </a>
 
         <nav class="flex items-center gap-4 sm:gap-6">
-          <a href="#docs" class="font-mono text-xs text-black/40 hover:text-black transition-colors">Docs</a>
+          <a href="{{ '/guide.html' | relative_url }}" class="font-mono text-xs text-black/40 hover:text-black transition-colors">Guide</a>
+          <a href="{{ '/agents.html' | relative_url }}" class="font-mono text-xs text-black/40 hover:text-black transition-colors">Agents</a>
+          <a href="{{ '/api-reference.html' | relative_url }}" class="font-mono text-xs text-black/40 hover:text-black transition-colors">API</a>
           <a href="https://github.com/Mellow-Artificial-Intelligence/openextract" class="font-mono text-xs text-black/40 hover:text-black transition-colors">GitHub</a>
           <a href="https://pypi.org/project/openextract/" class="font-mono text-xs text-black/40 hover:text-black transition-colors">PyPI</a>
         </nav>
@@ -114,6 +120,10 @@
 
           <!-- CTAs -->
           <div class="flex flex-col sm:flex-row gap-3 justify-center mb-10 sm:mb-14">
+            <a href="{{ '/guide.html' | relative_url }}"
+               class="h-10 px-5 bg-black text-white font-medium text-sm flex items-center justify-center hover:bg-black/80 transition-colors">
+               Read the guide
+            </a>
             <a href="https://github.com/Mellow-Artificial-Intelligence/openextract"
                class="h-10 px-5 bg-white border border-black/10 text-black font-medium text-sm flex items-center justify-center hover:bg-black/5 hover:border-black/20 transition-colors">
                View Source
@@ -345,31 +355,32 @@
       <section id="docs" class="py-16 sm:py-24 border-t border-black/5 scroll-mt-14">
         <div class="max-w-5xl mx-auto px-4 sm:px-6">
           <p class="font-mono text-[11px] text-black/40 uppercase tracking-wider mb-2">Documentation</p>
-          <h2 class="text-2xl sm:text-3xl font-bold text-black/90 mb-8 sm:mb-10">Guides and contracts</h2>
+          <h2 class="text-2xl sm:text-3xl font-bold text-black/90 mb-3">Guides and contracts</h2>
+          <p class="text-sm text-black/50 mb-8 sm:mb-10 max-w-2xl">Start with the guide. Coding agents should use the agent contract or <a href="{{ '/llms.txt' | relative_url }}" class="underline">llms.txt</a>.</p>
           <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/docs/api-reference.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+            <a href="{{ '/guide.html' | relative_url }}" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Guide</h3>
+              <p class="text-sm text-black/60 leading-relaxed">Install, inputs, styles, sessions, batch, errors, and CLI — the how-to.</p>
+            </a>
+            <a href="{{ '/agents.html' | relative_url }}" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">For agents</h3>
+              <p class="text-sm text-black/60 leading-relaxed">Which API to generate, input pitfalls, exceptions, and TestModel fixtures.</p>
+            </a>
+            <a href="{{ '/api-reference.html' | relative_url }}" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
               <h3 class="font-mono text-sm font-medium text-black/90 mb-2">API reference</h3>
               <p class="text-sm text-black/60 leading-relaxed">Public functions, sessions, input/result contracts, and common arguments.</p>
             </a>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/docs/cli.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+            <a href="{{ '/cli.html' | relative_url }}" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
               <h3 class="font-mono text-sm font-medium text-black/90 mb-2">CLI contracts</h3>
               <p class="text-sm text-black/60 leading-relaxed">Stdout, stderr, exit codes, retries, styles, and batch partial failures.</p>
             </a>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/docs/providers.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+            <a href="{{ '/providers.html' | relative_url }}" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
               <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Providers</h3>
               <p class="text-sm text-black/60 leading-relaxed">Capability matrix, extras, credentials, and verified vs expected media support.</p>
             </a>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/docs/troubleshooting.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+            <a href="{{ '/troubleshooting.html' | relative_url }}" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
               <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Troubleshooting</h3>
               <p class="text-sm text-black/60 leading-relaxed">Missing extras, URL fetch, schema failures, retries, and batch API choice.</p>
-            </a>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/README.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
-              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Quick start</h3>
-              <p class="text-sm text-black/60 leading-relaxed">Install, extract, sessions, styles, batch, CLI, and the public API stability table.</p>
-            </a>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
-              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Changelog</h3>
-              <p class="text-sm text-black/60 leading-relaxed">Unreleased work on main and the v0.10.0 release notes.</p>
             </a>
           </div>
         </div>
@@ -404,7 +415,7 @@
       <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row justify-between items-center gap-4">
         <span class="font-mono text-xs text-black/40">&copy; 2026 openextract. MIT License.</span>
         <div class="flex gap-6">
-          <a href="#docs" class="font-mono text-xs text-black/40 hover:text-black/60 transition-colors">Docs</a>
+          <a href="{{ '/guide.html' | relative_url }}" class="font-mono text-xs text-black/40 hover:text-black/60 transition-colors">Guide</a>
           <a href="https://github.com/Mellow-Artificial-Intelligence/openextract" class="font-mono text-xs text-black/40 hover:text-black/60 transition-colors">GitHub</a>
           <a href="https://pypi.org/project/openextract/" class="font-mono text-xs text-black/40 hover:text-black/60 transition-colors">PyPI</a>
         </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -78,6 +78,7 @@
         </a>
 
         <nav class="flex items-center gap-4 sm:gap-6">
+          <a href="#docs" class="font-mono text-xs text-black/40 hover:text-black transition-colors">Docs</a>
           <a href="https://github.com/Mellow-Artificial-Intelligence/openextract" class="font-mono text-xs text-black/40 hover:text-black transition-colors">GitHub</a>
           <a href="https://pypi.org/project/openextract/" class="font-mono text-xs text-black/40 hover:text-black transition-colors">PyPI</a>
         </nav>
@@ -93,9 +94,9 @@
           <!-- Badge -->
           <a href="#whats-new" class="animate-slide-up opacity-0 inline-flex items-center gap-2.5 px-3 py-1.5 border border-black/10 bg-white text-xs mb-8 hover:border-black/30 transition-colors">
             <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span>
-            <span class="font-mono text-black/40">v0.10.0</span>
+            <span class="font-mono text-black/40">on main</span>
             <span class="text-black/40">|</span>
-            <span class="text-black/40">non-blocking async I/O and smarter retries</span>
+            <span class="text-black/40">sessions, styles, and typed results</span>
           </a>
 
           <!-- Headline -->
@@ -160,7 +161,7 @@
               </div>
               <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Zero Config</h3>
               <p class="text-sm text-black/60 leading-relaxed">
-                One function call. Bring a schema, a URL, and an LLM model string.
+                One function call, or a reusable session. Bring a schema, media, and a model string.
               </p>
             </div>
 
@@ -180,7 +181,7 @@
               </div>
               <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Any LLM</h3>
               <p class="text-sm text-black/60 leading-relaxed">
-                11 providers wired in: OpenAI, Anthropic, Google, AWS Bedrock, xAI, Cohere, Hugging Face, Groq, Mistral, OpenRouter, and Ollama.
+                OpenAI, Anthropic, Google, Bedrock, xAI, Groq, Mistral, OpenRouter, Ollama, and more via pydantic-ai.
               </p>
             </div>
 
@@ -224,7 +225,7 @@
                   <div class="w-7 h-7 border border-black/10 flex items-center justify-center font-mono text-xs text-black/40 flex-shrink-0">2</div>
                   <div>
                     <h4 class="font-mono text-sm text-black/90 mb-1">Point at any media</h4>
-                    <p class="text-sm text-black/60">Documents, images, audio, or video via URL.</p>
+                    <p class="text-sm text-black/60">Documents, images, audio, or video via path, URL, bytes, or a session.</p>
                   </div>
                 </div>
                 <div class="flex gap-4">
@@ -264,36 +265,112 @@
         </div>
       </section>
 
-      <!-- What's new in 0.10.0 -->
+      <!-- What's new on main -->
       <section id="whats-new" class="py-16 sm:py-24 border-t border-black/5 scroll-mt-14">
         <div class="max-w-5xl mx-auto px-4 sm:px-6">
           <div class="flex items-baseline justify-between mb-8 sm:mb-10 flex-wrap gap-3">
             <div>
               <p class="font-mono text-[11px] text-black/40 uppercase tracking-wider mb-2">What&rsquo;s new</p>
-              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">v0.10.0</h2>
+              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">On main</h2>
+              <p class="text-sm text-black/40 mt-2">Unreleased on GitHub. Latest PyPI release is <span class="font-mono">v0.10.0</span>.</p>
             </div>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#0100---2026-08-01" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#unreleased" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
               Full changelog <i data-lucide="arrow-up-right" class="w-3 h-3"></i>
             </a>
           </div>
 
-          <div class="p-6 border border-black/10 bg-white">
-            <div class="flex items-center gap-3 mb-3">
-              <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                <i data-lucide="package" class="w-4 h-4 text-black/40"></i>
+          <div class="grid grid-cols-1 md:grid-cols-3 gap-3 sm:gap-4 mb-4">
+            <div class="p-6 border border-black/10 bg-white">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                  <i data-lucide="repeat" class="w-4 h-4 text-black/40"></i>
+                </div>
+                <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">Sessions</span>
               </div>
-              <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">v0.10.0 &middot; Performance</span>
+              <h3 class="font-mono text-base font-medium text-black/90 mb-2">Reusable extractors</h3>
+              <p class="text-sm text-black/60 leading-relaxed mb-4">
+                <code class="font-mono text-black/90 text-xs">Extractor</code> and <code class="font-mono text-black/90 text-xs">AsyncExtractor</code> build one agent, reuse HTTP clients, and close them on exit.
+              </p>
+              <div class="flex flex-wrap gap-1.5">
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">Extractor</span>
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">RetryPolicy</span>
+              </div>
             </div>
-            <h3 class="font-mono text-base font-medium text-black/90 mb-2">Non-blocking media and resilient retries</h3>
-            <p class="text-sm text-black/60 leading-relaxed mb-4">
-              Async APIs now offload disk, DNS, and file-like reads while reusing HTTP clients. Retries reuse prepared inputs and agents, retry only transient failures, and honor bounded <code class="font-mono text-black/90 text-xs">Retry-After</code> values.
-            </p>
-            <div class="flex flex-wrap gap-1.5">
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">async I/O</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">client reuse</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">transient retries</span>
-              <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">Retry-After</span>
+
+            <div class="p-6 border border-black/10 bg-white">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                  <i data-lucide="search" class="w-4 h-4 text-black/40"></i>
+                </div>
+                <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">Styles</span>
+              </div>
+              <h3 class="font-mono text-base font-medium text-black/90 mb-2">Direct, search, or code</h3>
+              <p class="text-sm text-black/60 leading-relaxed mb-4">
+                Send media in one shot, grep a text document with file tools, or let the model write Python against it.
+              </p>
+              <div class="flex flex-wrap gap-1.5">
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">direct</span>
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">search</span>
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">code</span>
+              </div>
             </div>
+
+            <div class="p-6 border border-black/10 bg-white">
+              <div class="flex items-center gap-3 mb-3">
+                <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
+                  <i data-lucide="layers" class="w-4 h-4 text-black/40"></i>
+                </div>
+                <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">Contracts</span>
+              </div>
+              <h3 class="font-mono text-base font-medium text-black/90 mb-2">Typed inputs and results</h3>
+              <p class="text-sm text-black/60 leading-relaxed mb-4">
+                Per-item media types, streaming batch yields, and <code class="font-mono text-black/90 text-xs">ExtractionResult</code> diagnostics without retaining raw media.
+              </p>
+              <div class="flex flex-wrap gap-1.5">
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">ExtractionInput</span>
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">streaming</span>
+              </div>
+            </div>
+          </div>
+
+          <p class="font-mono text-xs text-black/40">
+            Also on main: 50&nbsp;MiB input caps, OpenAI Responses by default, ExtractBench for any model.
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#0100---2026-08-01" class="hover:text-black/90 transition-colors">v0.10.0</a>
+            shipped non-blocking async I/O and transient-only retries.
+          </p>
+        </div>
+      </section>
+
+      <!-- Documentation -->
+      <section id="docs" class="py-16 sm:py-24 border-t border-black/5 scroll-mt-14">
+        <div class="max-w-5xl mx-auto px-4 sm:px-6">
+          <p class="font-mono text-[11px] text-black/40 uppercase tracking-wider mb-2">Documentation</p>
+          <h2 class="text-2xl sm:text-3xl font-bold text-black/90 mb-8 sm:mb-10">Guides and contracts</h2>
+          <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/docs/api-reference.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">API reference</h3>
+              <p class="text-sm text-black/60 leading-relaxed">Public functions, sessions, input/result contracts, and common arguments.</p>
+            </a>
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/docs/cli.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">CLI contracts</h3>
+              <p class="text-sm text-black/60 leading-relaxed">Stdout, stderr, exit codes, retries, styles, and batch partial failures.</p>
+            </a>
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/docs/providers.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Providers</h3>
+              <p class="text-sm text-black/60 leading-relaxed">Capability matrix, extras, credentials, and verified vs expected media support.</p>
+            </a>
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/docs/troubleshooting.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Troubleshooting</h3>
+              <p class="text-sm text-black/60 leading-relaxed">Missing extras, URL fetch, schema failures, retries, and batch API choice.</p>
+            </a>
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/README.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Quick start</h3>
+              <p class="text-sm text-black/60 leading-relaxed">Install, extract, sessions, styles, batch, CLI, and the public API stability table.</p>
+            </a>
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md" class="p-5 border border-black/10 bg-white hover:border-black/30 transition-colors">
+              <h3 class="font-mono text-sm font-medium text-black/90 mb-2">Changelog</h3>
+              <p class="text-sm text-black/60 leading-relaxed">Unreleased work on main and the v0.10.0 release notes.</p>
+            </a>
           </div>
         </div>
       </section>
@@ -327,6 +404,7 @@
       <div class="max-w-5xl mx-auto px-4 sm:px-6 flex flex-col sm:flex-row justify-between items-center gap-4">
         <span class="font-mono text-xs text-black/40">&copy; 2026 openextract. MIT License.</span>
         <div class="flex gap-6">
+          <a href="#docs" class="font-mono text-xs text-black/40 hover:text-black/60 transition-colors">Docs</a>
           <a href="https://github.com/Mellow-Artificial-Intelligence/openextract" class="font-mono text-xs text-black/40 hover:text-black/60 transition-colors">GitHub</a>
           <a href="https://pypi.org/project/openextract/" class="font-mono text-xs text-black/40 hover:text-black/60 transition-colors">PyPI</a>
         </div>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,45 @@
+# openextract
+
+> Extract structured Pydantic models from documents, images, audio, and video using LLMs.
+
+Python 3.12+. Install `openextract` plus a provider extra (`openextract[openai]`, `openextract[anthropic]`, `openextract[xai]`, or `openextract[all]`). The library does not load `.env` files; the CLI and examples do. Public API is `openextract.__all__`. Do not import `openextract._*` modules.
+
+Site: https://mellow-artificial-intelligence.github.io/openextract/
+Repo: https://github.com/Mellow-Artificial-Intelligence/openextract
+
+## Docs
+
+- [Guide](https://mellow-artificial-intelligence.github.io/openextract/guide.html): install, inputs, styles, sessions, batch, errors, CLI
+- [For agents](https://mellow-artificial-intelligence.github.io/openextract/agents.html): which API to generate, do-nots, TestModel
+- [API reference](https://mellow-artificial-intelligence.github.io/openextract/api-reference.html): CI-checked public signatures
+- [CLI contracts](https://mellow-artificial-intelligence.github.io/openextract/cli.html): stdout/stderr/exit codes
+- [Providers](https://mellow-artificial-intelligence.github.io/openextract/providers.html): extras, credentials, media matrix
+- [Troubleshooting](https://mellow-artificial-intelligence.github.io/openextract/troubleshooting.html): extras, URLs, retries, batch choice
+
+## Contract
+
+```python
+from pydantic import BaseModel
+from openextract import extract
+
+class Info(BaseModel):
+    summary: str
+
+extract(schema=Info, model="openai:gpt-5", input_file="doc.pdf")
+```
+
+Inputs: `str` path/URL, `pathlib.Path`, `bytes` or file-like (**`media_type` required**), or `ExtractionInput`. Default cap 50 MiB → `InputTooLargeError`.
+
+One-shot: `extract`, `extract_async`, `extract_with_usage`, `extract_with_usage_async`.
+Sessions: `Extractor`, `AsyncExtractor`, `RetryPolicy` (context managers; not thread-safe / one event loop).
+Batch (provisional): `extract_many` input order (not from a running loop); `iter_extract_many_async` completion-order `(index, result)`; `extract_many_with_results*` + `total_usage`.
+Styles: `direct` (default, any media); `search`/`code` text-only + `pydantic-ai-harness`.
+OpenAI: `openai:` → Responses API; `openai-chat:` for Chat Completions.
+
+Exceptions (all subclass `ExtractionError`): `UrlFetchError`, `InputTooLargeError`, `SchemaValidationError`, `ModelError` (`.retryable`, `.status_code`, `.provider`, `.retry_after`), `ProviderNotInstalledError`. Invalid retry/concurrency options raise `ValueError`.
+
+CLI: `openextract INPUT --schema mod:Class --model openai:gpt-5`. Exit 0 success; 1 usage; 2–6 mapped errors; 7 partial batch. Parse stdout only.
+
+Retries: `max_retries` default 0; only transient `ModelError`. Media is resolved once and reused.
+
+Tests without keys: `pydantic_ai.models.test.TestModel`.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -200,6 +200,8 @@ results = await extract_many_async(schema=..., model=..., input_files=...)
 
 ## Related
 
+- [Guide](guide.md)
+- [For agents](agents.md)
 - [CLI contracts](cli.md)
 - [Provider matrix](providers.md)
 - [README error handling](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/README.md#error-handling)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -169,6 +169,21 @@ Confirm the module imports cleanly: `python -c "import examples.cli.schemas"`.
 Inspect per-item `error` / `error_type` entries. Fix the failing inputs, or omit
 `--continue-on-error` / `return_exceptions` to fail fast on the first error.
 
+## Choosing a batch API
+
+- `extract_many` / `extract_many_async` wait for the full batch and return
+  results in **input order**.
+- `iter_extract_many_async` yields `(input_index, result)` in **completion
+  order**, consumes generators lazily, and never schedules more than
+  `max_concurrency` items. Use it when you want to start processing before the
+  last item finishes.
+- `extract_many_with_results*` keep input order and add per-item usage,
+  attempts, duration, and a sanitized source label.
+
+Default fail-fast cancels outstanding work after the first error.
+`return_exceptions=True` puts per-item exceptions in the result position and
+continues. See [API reference](api-reference.md#choosing-a-batch-api).
+
 ## Sync batch inside an async event loop
 
 **Symptoms**

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,6 +46,7 @@ uv run python -m examples.run_all
 | `images/` | `receipt_extraction.py` | Anthropic | Receipt-style fields from an image |
 | `documents/` | `invoice_extraction.py` | Anthropic | Invoice schema from PDF or image (`--fixture`) |
 | `batch/` | `batch_extract.py` | OpenAI | Concurrent `extract_many()` |
+| `batch/` | `stream_batch_extract.py` | TestModel | `iter_extract_many_async` completion order vs `extract_many` input order |
 | `async/` | `async_extract.py` | Anthropic | `extract_async()` |
 | `advanced/` | `extract_with_usage.py` | xAI | `extract_with_usage()` and token counts |
 | `advanced/` | `retry_extract.py` | OpenAI | `max_retries` / `retry_backoff` |

--- a/examples/batch/stream_batch_extract.py
+++ b/examples/batch/stream_batch_extract.py
@@ -9,6 +9,7 @@ from pydantic_ai.models.test import TestModel
 
 from openextract import ExtractionInput, extract_many, iter_extract_many_async
 
+
 class Contact(BaseModel):
     name: str
     email: str

--- a/examples/batch/stream_batch_extract.py
+++ b/examples/batch/stream_batch_extract.py
@@ -1,0 +1,66 @@
+"""Stream batch results in completion order with iter_extract_many_async."""
+
+from __future__ import annotations
+
+import asyncio
+
+from pydantic import BaseModel
+from pydantic_ai.models.test import TestModel
+
+from openextract import ExtractionInput, extract_many, iter_extract_many_async
+
+class Contact(BaseModel):
+    name: str
+    email: str
+
+
+MODEL = TestModel(custom_output_args={"name": "Ada Lovelace", "email": "ada@example.com"})
+
+INPUTS = [
+    ExtractionInput(b"Ada Lovelace <ada@example.com>", media_type="text/plain", name="ada.txt"),
+    ExtractionInput(b"missing media type", name="broken.bin"),
+    ExtractionInput(b"Grace Hopper <grace@example.com>", media_type="text/plain", name="grace.txt"),
+]
+
+
+def _print_item(index: int, result: Contact | Exception) -> None:
+    name = INPUTS[index].name
+    if isinstance(result, Exception):
+        print(f"  input[{index}] {name}: {type(result).__name__}: {result}")
+        return
+    print(f"  input[{index}] {name}: {result.email}")
+
+
+def list_api() -> None:
+    print("extract_many — input order, waits for the full batch:")
+    results = extract_many(
+        schema=Contact,
+        model=MODEL,
+        input_files=INPUTS,
+        return_exceptions=True,
+        max_concurrency=2,
+    )
+    for index, result in enumerate(results):
+        _print_item(index, result)
+
+
+async def stream_api() -> None:
+    print("iter_extract_many_async — completion order, yields as each item finishes:")
+    async for index, result in iter_extract_many_async(
+        schema=Contact,
+        model=MODEL,
+        input_files=INPUTS,
+        return_exceptions=True,
+        max_concurrency=2,
+    ):
+        _print_item(index, result)
+
+
+def main() -> None:
+    list_api()
+    print()
+    asyncio.run(stream_api())
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/run_all.py
+++ b/examples/run_all.py
@@ -32,6 +32,7 @@ NO_API_EXAMPLES: list[str] = [
     "examples.advanced.error_handling",
     "examples.advanced.reusable_sessions",
     "examples.advanced.extraction_styles",
+    "examples.batch.stream_batch_extract",
 ]
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -26,6 +26,7 @@ ALL_MODULES = [
     "examples.images.receipt_extraction",
     "examples.documents.invoice_extraction",
     "examples.batch.batch_extract",
+    "examples.batch.stream_batch_extract",
     "examples.async.async_extract",
     "examples.advanced.extract_with_usage",
     "examples.advanced.retry_extract",
@@ -91,6 +92,16 @@ def test_extraction_styles_example() -> None:
     result = _run("examples.advanced.extraction_styles")
     assert result.returncode == 0, result.stderr
     assert "Q4 notes" in result.stdout
+
+
+def test_stream_batch_extract_example() -> None:
+    result = _run("examples.batch.stream_batch_extract")
+    assert result.returncode == 0, result.stderr
+    assert "extract_many" in result.stdout
+    assert "iter_extract_many_async" in result.stdout
+    assert "ada@example.com" in result.stdout
+    assert "TypeError" in result.stdout
+    assert "broken.bin" in result.stdout
 
 
 @pytest.mark.integration


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The GitHub Pages site is now a real documentation site, not only a marketing page that links out to GitHub.

## Changes

- Build `docs/` with Jekyll on GitHub Pages (`deploy-docs.yml` builds `_site`; PRs that touch docs run the build without deploying).
- Add a [Guide](docs/guide.md) covering install, inputs, styles, sessions, batch, errors, and CLI.
- Add a [For agents](docs/agents.md) contract (which API to generate, input pitfalls, do-nots, TestModel) and [`llms.txt`](docs/llms.txt).
- Shared nav/sidebar so API, CLI, providers, troubleshooting, and maintainer pages render as HTML.
- Landing page CTAs point at the guide, agent page, and API instead of raw Markdown on GitHub.
- Streaming-batch example from the previous revision is unchanged.

## Testing

- `scripts/check_api_reference.py` still matches public signatures.
- Example smoke tests from the prior commit remain in place.
- Docs workflow now builds Jekyll on this PR so a failed site build is visible before merge.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a00d90-f9de-79a6-8e3b-464c4eb85898?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a00d90-f9de-79a6-8e3b-464c4eb85898&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

