### PR TITLE
Improve CLI ergonomics for large batch workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ timing when that is known.
 ## [Unreleased]
 
 ### Added
+- CLI batch ergonomics for large workflows: `--max-concurrency` (validated
+  before any model call), `--output jsonl` for incremental completion-order
+  records with an `index` field, `--progress` reporting on stderr only,
+  `--manifest` for JSONL per-input `source`/`media_type`/`name` configuration,
+  and `--usage` on batches with per-item plus aggregate token usage via the
+  rich result API. The default JSON array output and exit codes `0`-`7` are
+  unchanged; Ctrl-C now exits `130` and a closed stdout pipe exits `141`, with
+  cancellation, ordering, and partial-failure contracts documented in
+  `docs/cli.md`.
 - `scripts/extractbench.py` runs [ExtractBench](https://github.com/run-llama/ExtractBench)
   through openextract with any `pydantic-ai` model identifier (`--model openai:gpt-5 --test`).
 - Extraction styles: `style='direct'` (default) still sends media to the model

--- a/README.md
+++ b/README.md
@@ -346,15 +346,42 @@ openextract ./reports/q4.pdf \
   --output json
 ```
 
-Batch multiple files (JSON array output):
+Batch multiple files (JSON array output, `--max-concurrency` in-flight at once):
 
 ```bash
 openextract ./invoices/a.pdf ./invoices/b.pdf \
   --schema mypkg.schemas:Invoice \
-  --model xai:grok-4.3
+  --model xai:grok-4.3 \
+  --max-concurrency 8
 ```
 
-Token usage (single file):
+Stream a large batch as JSONL — each record is written the moment its input
+finishes, with progress on stderr, so downstream tooling can start consuming
+immediately:
+
+```bash
+openextract ./invoices/*.pdf \
+  --schema mypkg.schemas:Invoice \
+  --model xai:grok-4.3 \
+  --output jsonl --continue-on-error --progress \
+  | jq -c 'select(.result) | .result'
+```
+
+Mix media types in one run with a JSONL manifest (`source` required;
+`media_type` and `name` optional per line):
+
+```bash
+cat > inputs.jsonl <<'EOF'
+{"source": "./invoices/a.pdf", "media_type": "application/pdf", "name": "invoice-a"}
+{"source": "https://example.com/report", "media_type": "text/html"}
+EOF
+openextract --manifest inputs.jsonl \
+  --schema mypkg.schemas:Invoice \
+  --model xai:grok-4.3 \
+  --output jsonl
+```
+
+Token usage (single file or batch; batches add per-item and aggregate usage):
 
 ```bash
 openextract ./reports/q4.pdf \
@@ -379,9 +406,16 @@ cat ./reports/q4.pdf | openextract - \
 - `--style` is `direct` (default), `search` (file tools on text), or `code`
   (write Python against text). `search` needs `pydantic-ai-harness`; `code`
   needs `pydantic-ai-harness[codemode]`.
-- `--media-type` sets MIME type for stdin or overrides guessing for paths/URLs.
-- `--usage` prints a JSON object with `result` and `usage` (single input only).
-- `--output` is `json` (default) or `repr`.
+- `--media-type` sets MIME type for stdin, overrides guessing for paths/URLs,
+  and is the fallback for manifest entries without their own.
+- `--manifest` reads inputs from a JSONL file with per-item media types and
+  display names; mutually exclusive with positional inputs.
+- `--usage` prints `result` and `usage` for a single input; batches report
+  per-item usage plus an aggregate.
+- `--output` is `json` (default), `jsonl` (one record per completed input,
+  written incrementally in completion order with an `index` field), or `repr`.
+- `--max-concurrency` bounds in-flight extractions for batches (default 5).
+- `--progress` reports per-item batch completion on stderr only.
 - `--max-retries`, `--retry-backoff`, and `--retry-max-backoff` match the Python
   API retry behavior.
 - `--max-input-bytes` overrides the 50 MiB per-input cap.
@@ -389,12 +423,16 @@ cat ./reports/q4.pdf | openextract - \
   failure is emitted inline as `{"input", "error", "error_type"}` and the command
   exits `7` if any input failed. Without it, a batch aborts on the first failure.
 
+Concurrency, retry, and size options are validated before any model call.
+
 Exit codes: `0` success, `2` URL fetch error, `3` schema validation error, `4` model error,
 `5` other extraction error, `6` missing provider extra, `7` partial batch failure
-(`--continue-on-error`), `1` any other failure (including bad `--schema` paths).
+(`--continue-on-error`), `130` interrupted, `141` broken pipe, `1` any other
+failure (including bad `--schema` paths and invalid manifests).
 
-Extraction errors are written to stderr; successful JSON, usage payloads, and
-`--continue-on-error` batch arrays are written to stdout. Missing provider extras
+Extraction errors and progress are written to stderr; successful JSON, JSONL
+records, usage payloads, and `--continue-on-error` batch arrays are written to
+stdout. Missing provider extras
 exit `6` and include the same install hint as the Python API, for example
 `pip install 'openextract[xai]'`. Partial batch failures with `--continue-on-error`
 still print the full batch array to stdout, write a warning to stderr, and exit `7`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,34 +6,41 @@ title: CLI contracts
 # CLI stdout, stderr, and exit codes
 
 This page is the contract for the `openextract` command. Successful results go
-to **stdout**. Errors and warnings go to **stderr**. Exit codes are stable for
-automation.
+to **stdout**. Errors, warnings, and progress go to **stderr**. Exit codes are
+stable for automation.
 
 ## Streams
 
 | Stream | Contents |
 | ------ | -------- |
-| stdout | Successful extraction payloads (`json` or `repr`) |
-| stderr | `error: ...` messages, plus a `warning: ...` line for partial batch failures |
+| stdout | Successful extraction payloads (`json`, `jsonl`, or `repr`) |
+| stderr | `error: ...` messages, a `warning: ...` line for partial batch failures, and `progress: ...` lines when `--progress` is set |
 
 Never parse stderr for successful results. Never treat stdout as empty when
-exit code `7` is returned — the batch array is still written.
+exit code `7` is returned — the batch output is still written.
 
 ## Exit codes
 
 | Code | Meaning | Typical cause |
 | ---- | ------- | ------------- |
 | `0` | Success | Single-file or full-batch success |
-| `1` | Usage / setup error | Bad `--schema`, stdin without `--media-type`, `--usage` with multiple inputs, invalid retry/size options, argparse failures |
+| `1` | Usage / setup error | Bad `--schema`, stdin without `--media-type`, invalid manifest, invalid concurrency/retry/size options, argparse failures |
 | `2` | URL fetch error | `UrlFetchError` (network failure, HTTP error, SSRF refusal) |
 | `3` | Schema validation error | `SchemaValidationError` |
 | `4` | Model API error | `ModelError` |
 | `5` | Other extraction error | `InputTooLargeError` and other `ExtractionError` subclasses |
 | `6` | Missing provider SDK | `ProviderNotInstalledError` |
 | `7` | Partial batch failure | `--continue-on-error` with one or more per-item failures |
+| `130` | Interrupted | Ctrl-C / SIGINT; outstanding batch work is cancelled |
+| `141` | Broken pipe | stdout closed by the consumer (e.g. `head`); exits silently |
 
 These mappings live in `src/openextract/_cli.py` and are covered by
 `tests/test_cli.py`.
+
+CLI option values are validated **before any model call**: invalid
+`--max-concurrency`, `--max-retries`, `--retry-backoff`, `--retry-max-backoff`,
+`--max-input-bytes`, or manifest contents exit `1` without contacting a
+provider.
 
 ## Successful single-file output
 
@@ -53,13 +60,98 @@ openextract ./reports/q4.pdf \
 ```bash
 openextract ./invoices/a.pdf ./invoices/b.pdf \
   --schema mypkg.schemas:Invoice \
-  --model xai:grok-4.3
+  --model xai:grok-4.3 \
+  --max-concurrency 8
 ```
 
 - Exit `0` when every item succeeds.
 - stdout: JSON array of per-item `model_dump()` objects, in input order.
+- `--max-concurrency N` bounds in-flight extractions (default `5`); it must be
+  a positive integer.
+
+## JSONL output for large batches
+
+```bash
+openextract ./invoices/*.pdf \
+  --schema mypkg.schemas:Invoice \
+  --model xai:grok-4.3 \
+  --output jsonl --continue-on-error
+```
+
+`--output jsonl` writes one JSON record per line as each input **completes**,
+flushed immediately, so large batches emit useful output long before the batch
+finishes. Records arrive in completion order; `index` is the zero-based input
+position, so consumers can reorder or join back to their inputs.
+
+```json
+{"index": 1, "input": "./invoices/b.pdf", "result": {"total": 42.0}}
+{"index": 0, "input": "./invoices/a.pdf", "error": "...", "error_type": "ModelError"}
+```
+
+- Success records: `{"index", "input", "result"}` (plus `"usage"` with
+  `--usage`).
+- Failure records (`--continue-on-error` only): `{"index", "input", "error",
+  "error_type"}`.
+- With `--usage`, a final `{"summary": {"inputs", "failed", "usage"}}` line
+  carries aggregate usage; it is the only non-record line.
+- A single input with `--output jsonl` uses the same batch semantics and record
+  shapes.
+- Without `--continue-on-error`, the first failure cancels outstanding work;
+  records already written remain on stdout, the error goes to stderr, and the
+  exit code maps as usual (`2`–`6`).
+
+## Progress reporting
+
+```bash
+openextract ./invoices/*.pdf \
+  --schema mypkg.schemas:Invoice \
+  --model xai:grok-4.3 \
+  --output jsonl --progress 2>progress.log
+```
+
+`--progress` writes one line per completed batch item to **stderr only**:
+
+```
+progress: 3/10 completed (1 failed): ./invoices/c.pdf
+```
+
+stdout stays machine-readable. Progress lines are human-oriented; do not parse
+them. The flag is a no-op for single-input runs.
+
+## Manifest input
+
+```bash
+openextract --manifest inputs.jsonl \
+  --schema mypkg.schemas:Invoice \
+  --model xai:grok-4.3 \
+  --output jsonl
+```
+
+`--manifest FILE` reads inputs from a JSONL file instead of positional
+arguments, so heterogeneous batches can set per-input media types:
+
+```json
+{"source": "./invoices/a.pdf", "media_type": "application/pdf", "name": "invoice-a"}
+{"source": "https://example.com/report", "media_type": "text/html"}
+{"source": "./notes.txt"}
+```
+
+- `source` (required): a path or `http(s)://` URL. Stdin (`-`) is not
+  supported inside manifests.
+- `media_type` (optional): per-item MIME type. Entries without one fall back
+  to `--media-type`, then to inference.
+- `name` (optional): safe display label used in JSONL records, progress lines,
+  and error entries instead of the source.
+- Blank lines are skipped; unknown keys are rejected.
+- `--manifest` is mutually exclusive with positional inputs and always uses
+  batch semantics (a one-entry manifest still emits a JSON array or JSONL
+  records).
+- Invalid manifests exit `1` with a `manifest line N: ...` error before any
+  model call.
 
 ## `--usage` output
+
+Single input:
 
 ```bash
 openextract ./reports/q4.pdf \
@@ -67,9 +159,6 @@ openextract ./reports/q4.pdf \
   --model xai:grok-4.3 \
   --usage
 ```
-
-- Single input only; multiple inputs exit `1` with an error on stderr.
-- stdout JSON shape:
 
 ```json
 {
@@ -82,14 +171,38 @@ openextract ./reports/q4.pdf \
 }
 ```
 
-## `--output json` and `--output repr`
+Batches run through the richer result API and report per-item **and**
+aggregate usage:
+
+```bash
+openextract ./invoices/a.pdf ./invoices/b.pdf \
+  --schema mypkg.schemas:Invoice \
+  --model xai:grok-4.3 \
+  --usage
+```
+
+```json
+{
+  "results": [
+    { "input": "./invoices/a.pdf", "result": { "...": "..." }, "usage": { "...": 0 } },
+    { "input": "./invoices/b.pdf", "error": "...", "error_type": "ModelError" }
+  ],
+  "usage": { "input_tokens": 0, "output_tokens": 0, "total_tokens": 0 }
+}
+```
+
+The aggregate sums successful items only. With `--output jsonl`, usage appears
+on each success record and in the final `summary` line instead.
+
+## `--output json`, `--output jsonl`, and `--output repr`
 
 | Flag | Behavior |
 | ---- | -------- |
-| `--output json` (default) | Pretty-printed JSON (`indent=2`). Single-file non-usage results use `model_dump_json`. |
-| `--output repr` | Python `repr(...)` of the same payload object. |
+| `--output json` (default) | Pretty-printed JSON (`indent=2`), buffered until the run finishes. Single-file non-usage results use `model_dump_json`. Batch arrays are in input order. |
+| `--output jsonl` | One compact JSON record per completed input, written incrementally in completion order. |
+| `--output repr` | Python `repr(...)` of the same payload object as `json`. |
 
-Both formats write only to stdout on success.
+All formats write only to stdout on success.
 
 ## Stdin input
 
@@ -103,7 +216,7 @@ cat ./reports/q4.pdf | openextract - \
 - `-` reads raw bytes from stdin.
 - Stdin is read in bounded chunks under the same input-size limit as files and URLs.
 - `--media-type` is required.
-- `-` cannot be combined with other input paths (exit `1`).
+- `-` cannot be combined with other input paths or manifests (exit `1`).
 
 ## `--continue-on-error` partial failures
 
@@ -114,7 +227,7 @@ openextract ./ok.pdf ./missing.pdf \
   --continue-on-error
 ```
 
-- stdout still receives the full JSON array.
+- stdout still receives the full JSON array (or every JSONL record).
 - Failed items appear as:
 
 ```json
@@ -125,10 +238,21 @@ openextract ./ok.pdf ./missing.pdf \
 }
 ```
 
+- Failures always preserve input identity: the `input` field is the positional
+  argument as given, or the manifest `name`/`source`.
 - stderr receives a warning: `warning: N of M input(s) failed; see output for details`.
 - Exit `7` when any item failed; exit `0` when none failed.
-- Without `--continue-on-error`, the first failure aborts and maps to exit codes
-  `2`–`6` / `1` as usual (no batch array).
+- Without `--continue-on-error`, the first failure cancels outstanding work and
+  maps to exit codes `2`–`6` / `1` as usual (no batch array; JSONL records
+  already emitted remain).
+
+## Cancellation and broken pipes
+
+- **Ctrl-C / SIGINT**: outstanding batch work is cancelled and awaited, an
+  `error: interrupted` line goes to stderr, and the exit code is `130`.
+- **Broken pipe**: when the stdout consumer closes early (e.g.
+  `openextract ... --output jsonl | head -5`), the CLI stops scheduling work,
+  cancels what is in flight, and exits `141` without writing anything further.
 
 ## Retry policy
 

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -3,18 +3,26 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import importlib
 import json
+import os
 import sys
-from collections.abc import Sequence
+from collections.abc import AsyncGenerator, Sequence
 from typing import Any, BinaryIO, cast
 
 from dotenv import load_dotenv
 from pydantic import BaseModel
 
-from ._batch import extract_many
+from ._batch import _iter_extractions
+from ._config import (
+    _resolve_max_input_bytes,
+    _validate_max_concurrency,
+    _validate_retry_options,
+)
 from ._extract import extract, extract_with_usage
-from ._styles import ExtractionStyle
+from ._styles import ExtractionStyle, normalize_style
+from ._types import ExtractionInput, ExtractionInputLike, ExtractionResult
 from .exceptions import (
     ExtractionError,
     ModelError,
@@ -22,6 +30,11 @@ from .exceptions import (
     SchemaValidationError,
     UrlFetchError,
 )
+
+_EXIT_PARTIAL_FAILURE = 7
+_EXIT_INTERRUPTED = 130  # 128 + SIGINT, the conventional Ctrl-C exit code
+_EXIT_BROKEN_PIPE = 141  # 128 + SIGPIPE, the conventional broken-pipe exit code
+_MANIFEST_KEYS = frozenset({"source", "media_type", "name"})
 
 
 def _resolve_schema(schema_path: str) -> type[BaseModel]:
@@ -65,6 +78,60 @@ def _resolve_input_files(
     return cast(list[str | bytes | BinaryIO], raw_inputs)
 
 
+def _parse_manifest_entry(text: str, line_number: int) -> ExtractionInput:
+    """Validate one manifest line and build its ``ExtractionInput``."""
+    try:
+        record = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"manifest line {line_number}: invalid JSON: {exc}") from exc
+    if not isinstance(record, dict):
+        raise ValueError(f"manifest line {line_number}: expected a JSON object")
+    unknown = sorted(set(record) - _MANIFEST_KEYS)
+    if unknown:
+        raise ValueError(f"manifest line {line_number}: unknown keys: {', '.join(unknown)}")
+    source = record.get("source")
+    if not isinstance(source, str) or not source:
+        raise ValueError(f"manifest line {line_number}: 'source' must be a non-empty string")
+    if source == "-":
+        raise ValueError(f"manifest line {line_number}: stdin (-) is not supported in manifests")
+    media_type = record.get("media_type")
+    if media_type is not None and not isinstance(media_type, str):
+        raise ValueError(f"manifest line {line_number}: 'media_type' must be a string")
+    name = record.get("name")
+    if name is not None and not isinstance(name, str):
+        raise ValueError(f"manifest line {line_number}: 'name' must be a string")
+    return ExtractionInput(source=source, media_type=media_type, name=name)
+
+
+def _load_manifest(path: str) -> list[ExtractionInput]:
+    """Parse a JSONL manifest file into per-item extraction inputs."""
+    entries: list[ExtractionInput] = []
+    with open(path, encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            text = line.strip()
+            if not text:
+                continue
+            entries.append(_parse_manifest_entry(text, line_number))
+    if not entries:
+        raise ValueError(f"manifest '{path}' contains no entries")
+    return entries
+
+
+def _resolve_cli_inputs(
+    args: argparse.Namespace,
+) -> tuple[list[ExtractionInputLike], list[str]]:
+    """Resolve positional inputs or a manifest into items plus display labels."""
+    if args.manifest is not None:
+        if args.input_files:
+            raise ValueError("--manifest cannot be combined with positional input files")
+        entries = _load_manifest(args.manifest)
+        return list(entries), [entry.name or cast(str, entry.source) for entry in entries]
+    if not args.input_files:
+        raise ValueError("provide one or more input files, or --manifest")
+    resolved = _resolve_input_files(args.input_files, media_type=args.media_type)
+    return cast(list[ExtractionInputLike], resolved), list(args.input_files)
+
+
 def _usage_payload(usage) -> dict[str, int]:
     return {
         "input_tokens": usage.input_tokens,
@@ -73,38 +140,209 @@ def _usage_payload(usage) -> dict[str, int]:
     }
 
 
-def _batch_payload(
-    results: list,
-    inputs: list[str | bytes | BinaryIO],
-) -> tuple[list[Any], int]:
-    """Build the JSON entries for a batch run and count per-item failures.
+def _failure_record(label: str, error: BaseException) -> dict[str, Any]:
+    return {
+        "input": label,
+        "error": str(error),
+        "error_type": type(error).__name__,
+    }
 
-    Successful items serialize to their model dump. Failed items (only present
-    when ``--continue-on-error`` runs the batch with ``return_exceptions=True``)
-    become an error object tagged with the originating input.
-    """
-    payload: list[Any] = []
-    failures = 0
-    for item, result in zip(inputs, results, strict=True):
-        if isinstance(result, BaseException):
-            failures += 1
-            payload.append(
-                {
-                    "input": item if isinstance(item, str) else "<bytes>",
-                    "error": str(result),
-                    "error_type": type(result).__name__,
-                }
-            )
-        else:
-            payload.append(result.model_dump())
-    return payload, failures
+
+def _item_record(label: str, result: object, *, with_usage: bool) -> dict[str, Any]:
+    """Build the labeled record for one completed batch item."""
+    if isinstance(result, BaseException):
+        return _failure_record(label, result)
+    if with_usage:
+        rich = cast(ExtractionResult[Any], result)
+        return {
+            "input": label,
+            "result": rich.output.model_dump(),
+            "usage": _usage_payload(rich.usage),
+        }
+    return {"input": label, "result": cast(BaseModel, result).model_dump()}
+
+
+def _array_entry(label: str, result: object, *, with_usage: bool) -> Any:
+    """Build one JSON-array entry, keeping the legacy bare shape for successes."""
+    if with_usage or isinstance(result, BaseException):
+        return _item_record(label, result, with_usage=with_usage)
+    return cast(BaseModel, result).model_dump()
 
 
 def _print_json(payload: Any, *, as_repr: bool) -> None:
     if as_repr:
-        print(repr(payload))
+        print(repr(payload), flush=True)
         return
-    print(json.dumps(payload, indent=2, default=str))
+    print(json.dumps(payload, indent=2, default=str), flush=True)
+
+
+def _emit_json_line(record: dict[str, Any]) -> None:
+    """Write one JSONL record and flush so consumers see it immediately."""
+    print(json.dumps(record, default=str), flush=True)
+
+
+def _discard_stdout() -> None:
+    """Point stdout at ``os.devnull`` so interpreter-exit flushes stay quiet."""
+    try:
+        devnull = os.open(os.devnull, os.O_WRONLY)
+        os.dup2(devnull, sys.stdout.fileno())
+        os.close(devnull)
+    except OSError:
+        pass
+
+
+def _print_batch_payload(
+    ordered: list[tuple[int, object]],
+    labels: list[str],
+    usage_totals: dict[str, int],
+    *,
+    with_usage: bool,
+    as_repr: bool,
+) -> None:
+    """Emit the buffered batch payload in input order."""
+    ordered.sort(key=lambda pair: pair[0])
+    entries = [
+        _array_entry(labels[index], result, with_usage=with_usage) for index, result in ordered
+    ]
+    payload: Any = {"results": entries, "usage": usage_totals} if with_usage else entries
+    _print_json(payload, as_repr=as_repr)
+
+
+async def _run_batch_async(
+    schema_cls: type[BaseModel],
+    items: list[ExtractionInputLike],
+    labels: list[str],
+    limit: int,
+    args: argparse.Namespace,
+) -> int:
+    """Stream the batch, emitting records (JSONL) or buffering them (array)."""
+    with_usage = args.usage
+    jsonl = args.output == "jsonl"
+    # _iter_extractions is an async generator function; its AsyncIterator return
+    # annotation hides the aclose() needed for deterministic finalization.
+    stream = cast(
+        "AsyncGenerator[tuple[int, object], None]",
+        _iter_extractions(
+            schema_cls,
+            args.model,
+            items,
+            args.instructions,
+            max_concurrency=args.max_concurrency,
+            return_exceptions=args.continue_on_error,
+            media_type=args.media_type,
+            max_input_bytes=limit,
+            max_retries=args.max_retries,
+            retry_backoff=args.retry_backoff,
+            retry_max_backoff=args.retry_max_backoff,
+            rich=with_usage,
+            style=normalize_style(args.style),
+        ),
+    )
+    total = len(items)
+    ordered: list[tuple[int, object]] = []
+    completed = 0
+    failed = 0
+    usage_totals = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    try:
+        async for index, result in stream:
+            completed += 1
+            if isinstance(result, BaseException):
+                failed += 1
+            elif with_usage:
+                usage = cast(ExtractionResult[Any], result).usage
+                usage_totals["input_tokens"] += usage.input_tokens
+                usage_totals["output_tokens"] += usage.output_tokens
+                usage_totals["total_tokens"] += usage.total_tokens
+            if jsonl:
+                record = _item_record(labels[index], result, with_usage=with_usage)
+                _emit_json_line({"index": index, **record})
+            else:
+                ordered.append((index, result))
+            if args.progress:
+                print(
+                    f"progress: {completed}/{total} completed ({failed} failed): {labels[index]}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+    finally:
+        # Deterministically finalize the generator so outstanding work is
+        # cancelled before the event loop closes, even on emit failures.
+        await stream.aclose()
+
+    if jsonl:
+        if with_usage:
+            _emit_json_line({"summary": {"inputs": total, "failed": failed, "usage": usage_totals}})
+    else:
+        _print_batch_payload(
+            ordered,
+            labels,
+            usage_totals,
+            with_usage=with_usage,
+            as_repr=args.output == "repr",
+        )
+
+    if failed:
+        print(
+            f"warning: {failed} of {total} input(s) failed; see output for details",
+            file=sys.stderr,
+        )
+        return _EXIT_PARTIAL_FAILURE
+    return 0
+
+
+def _run_batch(
+    schema_cls: type[BaseModel],
+    items: list[ExtractionInputLike],
+    labels: list[str],
+    args: argparse.Namespace,
+) -> int:
+    """Validate batch options before any model call, then run the batch."""
+    _validate_retry_options(args.max_retries, args.retry_backoff, args.retry_max_backoff)
+    limit = _resolve_max_input_bytes(args.max_input_bytes)
+    return asyncio.run(_run_batch_async(schema_cls, items, labels, limit, args))
+
+
+def _run_single(
+    schema_cls: type[BaseModel],
+    input_file: ExtractionInputLike,
+    args: argparse.Namespace,
+) -> int:
+    """Run a single extraction with the legacy output shapes."""
+    if args.usage:
+        result, usage = extract_with_usage(
+            schema=schema_cls,
+            model=args.model,
+            input_file=input_file,
+            instructions=args.instructions,
+            style=args.style,
+            media_type=args.media_type,
+            max_input_bytes=args.max_input_bytes,
+            max_retries=args.max_retries,
+            retry_backoff=args.retry_backoff,
+            retry_max_backoff=args.retry_max_backoff,
+        )
+        payload: Any = {"result": result.model_dump(), "usage": _usage_payload(usage)}
+    else:
+        payload = extract(
+            schema=schema_cls,
+            model=args.model,
+            input_file=input_file,
+            instructions=args.instructions,
+            style=args.style,
+            media_type=args.media_type,
+            max_input_bytes=args.max_input_bytes,
+            max_retries=args.max_retries,
+            retry_backoff=args.retry_backoff,
+            retry_max_backoff=args.retry_max_backoff,
+        )
+
+    if args.output == "repr":
+        _print_json(payload, as_repr=True)
+    elif not args.usage and isinstance(payload, BaseModel):
+        print(payload.model_dump_json(indent=2))
+    else:
+        _print_json(payload, as_repr=False)
+    return 0
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -114,9 +352,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "input_files",
-        nargs="+",
+        nargs="*",
         metavar="input_file",
-        help="One or more paths/URLs, or '-' to read bytes from stdin.",
+        help=(
+            "One or more paths/URLs, or '-' to read bytes from stdin. Omit when using --manifest."
+        ),
     )
     parser.add_argument(
         "--schema",
@@ -146,12 +386,28 @@ def _build_parser() -> argparse.ArgumentParser:
         "--media-type",
         default=None,
         metavar="MIME",
-        help="MIME type (required for stdin; optional override for paths/URLs).",
+        help=(
+            "MIME type (required for stdin; optional override for paths/URLs "
+            "and fallback for manifest entries without their own)."
+        ),
+    )
+    parser.add_argument(
+        "--manifest",
+        default=None,
+        metavar="FILE",
+        help=(
+            'JSONL file of inputs, one {"source": ..., "media_type"?: ..., '
+            '"name"?: ...} object per line. Mutually exclusive with positional '
+            "input files; always uses batch semantics."
+        ),
     )
     parser.add_argument(
         "--usage",
         action="store_true",
-        help="Print token usage (single input only).",
+        help=(
+            "Include token usage: single inputs keep the {result, usage} shape; "
+            "batches report per-item and aggregate usage."
+        ),
     )
     parser.add_argument(
         "--continue-on-error",
@@ -163,9 +419,24 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--output",
-        choices=("json", "repr"),
+        choices=("json", "jsonl", "repr"),
         default="json",
-        help="Output format: 'json' (default) or 'repr'.",
+        help=(
+            "Output format: 'json' (default), 'jsonl' (one record per completed "
+            "input, written incrementally), or 'repr'."
+        ),
+    )
+    parser.add_argument(
+        "--max-concurrency",
+        type=int,
+        default=5,
+        metavar="N",
+        help="Maximum in-flight extractions for batch runs (default 5).",
+    )
+    parser.add_argument(
+        "--progress",
+        action="store_true",
+        help="Batch only: report per-item completion progress on stderr.",
     )
     parser.add_argument(
         "--max-retries",
@@ -213,63 +484,25 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 1
 
     try:
-        input_files = _resolve_input_files(args.input_files, media_type=args.media_type)
+        items, labels = _resolve_cli_inputs(args)
+    except OSError as exc:
+        print(f"error: cannot read manifest: {exc}", file=sys.stderr)
+        return 1
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 
-    if args.usage and len(input_files) != 1:
-        print("error: --usage requires exactly one input file", file=sys.stderr)
-        return 1
-
-    media_type = args.media_type
-    batch_failures = 0
-
     try:
-        if len(input_files) == 1:
-            input_file = input_files[0]
-            if args.usage:
-                result, usage = extract_with_usage(
-                    schema=schema_cls,
-                    model=args.model,
-                    input_file=input_file,
-                    instructions=args.instructions,
-                    style=args.style,
-                    media_type=media_type,
-                    max_input_bytes=args.max_input_bytes,
-                    max_retries=args.max_retries,
-                    retry_backoff=args.retry_backoff,
-                    retry_max_backoff=args.retry_max_backoff,
-                )
-                payload: Any = {"result": result.model_dump(), "usage": _usage_payload(usage)}
-            else:
-                payload = extract(
-                    schema=schema_cls,
-                    model=args.model,
-                    input_file=input_file,
-                    instructions=args.instructions,
-                    style=args.style,
-                    media_type=media_type,
-                    max_input_bytes=args.max_input_bytes,
-                    max_retries=args.max_retries,
-                    retry_backoff=args.retry_backoff,
-                    retry_max_backoff=args.retry_max_backoff,
-                )
-        else:
-            results = extract_many(
-                schema=schema_cls,
-                model=args.model,
-                input_files=input_files,
-                instructions=args.instructions,
-                style=args.style,
-                media_type=media_type,
-                max_input_bytes=args.max_input_bytes,
-                max_retries=args.max_retries,
-                retry_backoff=args.retry_backoff,
-                retry_max_backoff=args.retry_max_backoff,
-                return_exceptions=args.continue_on_error,
-            )
-            payload, batch_failures = _batch_payload(results, input_files)
+        _validate_max_concurrency(args.max_concurrency)
+        if args.manifest is not None or len(items) > 1 or args.output == "jsonl":
+            return _run_batch(schema_cls, items, labels, args)
+        return _run_single(schema_cls, items[0], args)
+    except BrokenPipeError:
+        _discard_stdout()
+        return _EXIT_BROKEN_PIPE
+    except KeyboardInterrupt:
+        print("error: interrupted", file=sys.stderr)
+        return _EXIT_INTERRUPTED
     except UrlFetchError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2
@@ -288,22 +521,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
-
-    if args.output == "repr":
-        _print_json(payload, as_repr=True)
-    elif len(input_files) == 1 and not args.usage and isinstance(payload, BaseModel):
-        print(payload.model_dump_json(indent=2))
-    else:
-        _print_json(payload, as_repr=False)
-
-    if batch_failures:
-        print(
-            f"warning: {batch_failures} of {len(input_files)} input(s) failed; "
-            "see output for details",
-            file=sys.stderr,
-        )
-        return 7  # partial batch failure under --continue-on-error
-    return 0
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,8 @@
 """Tests for openextract._cli."""
 
+import io
+import json
+import sys
 from unittest.mock import MagicMock
 
 import pytest
@@ -7,13 +10,17 @@ from pydantic import BaseModel
 
 from openextract import (
     ExtractionError,
+    ExtractionInput,
+    ExtractionResult,
+    ExtractionStyle,
     InputTooLargeError,
     ModelError,
     ProviderNotInstalledError,
     SchemaValidationError,
     UrlFetchError,
+    Usage,
 )
-from openextract._cli import _resolve_schema, main
+from openextract._cli import _discard_stdout, _resolve_schema, main
 
 
 class _FixtureSchema(BaseModel):
@@ -43,13 +50,31 @@ def _patch_extract_with_usage(mocker, return_value=None, side_effect=None):
     return mock_fn
 
 
-def _patch_extract_many(mocker, return_value=None, side_effect=None):
-    mock_fn = mocker.patch("openextract._cli.extract_many")
-    if side_effect is not None:
-        mock_fn.side_effect = side_effect
-    else:
-        mock_fn.return_value = return_value
-    return mock_fn
+def _patch_iter_extractions(mocker, events=(), error=None):
+    """Patch the CLI's batch stream with a fake indexed async iterator."""
+
+    async def _stream(*_args, **_kwargs):
+        for event in events:
+            yield event
+        if error is not None:
+            raise error
+
+    return mocker.patch("openextract._cli._iter_extractions", side_effect=_stream)
+
+
+def _rich_result(output, input_tokens=10, output_tokens=5):
+    return ExtractionResult(
+        output=output,
+        usage=Usage(input_tokens, output_tokens, input_tokens + output_tokens),
+        attempts=1,
+        duration=0.1,
+        model="xai:grok-4.3",
+        media_type=None,
+        source="fixture",
+    )
+
+
+_BASE_ARGS = ["--schema", "tests.test_cli:_FixtureSchema", "--model", "xai:grok-4.3"]
 
 
 # ---------------------------------------------------------------------------
@@ -116,24 +141,19 @@ class TestArgparse:
 
     def test_invalid_output_choice_exits_nonzero(self, capsys):
         with pytest.raises(SystemExit) as exc_info:
-            main(
-                [
-                    "input.txt",
-                    "--schema",
-                    "tests.test_cli:_FixtureSchema",
-                    "--model",
-                    "xai:grok-4.3",
-                    "--output",
-                    "yaml",
-                ]
-            )
+            main(["input.txt", *_BASE_ARGS, "--output", "yaml"])
         assert exc_info.value.code != 0
         captured = capsys.readouterr()
         assert "output" in captured.err.lower()
 
+    def test_no_inputs_and_no_manifest_returns_1(self, capsys):
+        exit_code = main(_BASE_ARGS)
+        assert exit_code == 1
+        assert "input files" in capsys.readouterr().err
+
 
 # ---------------------------------------------------------------------------
-# main success paths
+# main success paths (single input)
 # ---------------------------------------------------------------------------
 
 
@@ -142,20 +162,7 @@ class TestMainSuccess:
         fake = _FixtureSchema(name="Ada", age=36)
         mock_extract = _patch_extract(mocker, return_value=fake)
 
-        assert (
-            main(
-                [
-                    "input.txt",
-                    "--schema",
-                    "tests.test_cli:_FixtureSchema",
-                    "--model",
-                    "openai:gpt-5",
-                    "--max-input-bytes",
-                    "1024",
-                ]
-            )
-            == 0
-        )
+        assert main(["input.txt", *_BASE_ARGS, "--max-input-bytes", "1024"]) == 0
 
         assert mock_extract.call_args.kwargs["max_input_bytes"] == 1024
         capsys.readouterr()
@@ -164,18 +171,7 @@ class TestMainSuccess:
         load_dotenv = mocker.patch("openextract._cli.load_dotenv")
         _patch_extract(mocker, return_value=_FixtureSchema(name="Ada", age=36))
 
-        assert (
-            main(
-                [
-                    "input.txt",
-                    "--schema",
-                    "tests.test_cli:_FixtureSchema",
-                    "--model",
-                    "openai:gpt-5",
-                ]
-            )
-            == 0
-        )
+        assert main(["input.txt", *_BASE_ARGS]) == 0
 
         load_dotenv.assert_called_once_with()
         capsys.readouterr()
@@ -184,17 +180,7 @@ class TestMainSuccess:
         fake = _FixtureSchema(name="Ada", age=36)
         mock_extract = _patch_extract(mocker, return_value=fake)
 
-        exit_code = main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--instructions",
-                "find the person",
-            ]
-        )
+        exit_code = main(["input.txt", *_BASE_ARGS, "--instructions", "find the person"])
 
         assert exit_code == 0
         captured = capsys.readouterr()
@@ -217,17 +203,7 @@ class TestMainSuccess:
         fake.__repr__ = lambda self: "_FixtureSchema(name='Linus', age=54)"
         _patch_extract(mocker, return_value=fake)
 
-        exit_code = main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--output",
-                "repr",
-            ]
-        )
+        exit_code = main(["input.txt", *_BASE_ARGS, "--output", "repr"])
 
         assert exit_code == 0
         captured = capsys.readouterr()
@@ -238,15 +214,7 @@ class TestMainSuccess:
         fake.model_dump_json.return_value = "{}"
         mock_extract = _patch_extract(mocker, return_value=fake)
 
-        exit_code = main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-            ]
-        )
+        exit_code = main(["input.txt", *_BASE_ARGS])
 
         assert exit_code == 0
         assert mock_extract.call_args.kwargs["instructions"] is None
@@ -256,15 +224,7 @@ class TestMainSuccess:
         fake.model_dump_json.return_value = "{}"
         mock_extract = _patch_extract(mocker, return_value=fake)
 
-        main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-            ]
-        )
+        main(["input.txt", *_BASE_ARGS])
 
         assert mock_extract.call_args.kwargs["max_retries"] == 0
         assert mock_extract.call_args.kwargs["retry_backoff"] == 1.0
@@ -278,10 +238,7 @@ class TestMainSuccess:
         main(
             [
                 "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
+                *_BASE_ARGS,
                 "--max-retries",
                 "3",
                 "--retry-backoff",
@@ -296,52 +253,31 @@ class TestMainSuccess:
         assert mock_extract.call_args.kwargs["retry_max_backoff"] == 12.0
 
     def test_invalid_max_retries_returns_1(self, capsys):
-        exit_code = main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--max-retries",
-                "-1",
-            ]
-        )
+        exit_code = main(["input.txt", *_BASE_ARGS, "--max-retries", "-1"])
 
         assert exit_code == 1
         assert "max_retries" in capsys.readouterr().err
 
     def test_invalid_retry_backoff_returns_1(self, capsys):
-        exit_code = main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--retry-backoff",
-                "-0.1",
-            ]
-        )
+        exit_code = main(["input.txt", *_BASE_ARGS, "--retry-backoff", "-0.1"])
 
         assert exit_code == 1
         assert "retry_backoff" in capsys.readouterr().err
 
     def test_invalid_retry_max_backoff_returns_1(self, capsys):
-        exit_code = main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--retry-max-backoff",
-                "-1",
-            ]
-        )
+        exit_code = main(["input.txt", *_BASE_ARGS, "--retry-max-backoff", "-1"])
 
         assert exit_code == 1
         assert "retry_max_backoff" in capsys.readouterr().err
+
+    def test_invalid_max_concurrency_returns_1_before_extraction(self, mocker, capsys):
+        mock_extract = _patch_extract(mocker)
+
+        exit_code = main(["input.txt", *_BASE_ARGS, "--max-concurrency", "0"])
+
+        assert exit_code == 1
+        assert "max_concurrency" in capsys.readouterr().err
+        mock_extract.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -353,30 +289,14 @@ class TestMainErrorCodes:
     def test_input_too_large_returns_5(self, mocker, capsys):
         _patch_extract(mocker, side_effect=InputTooLargeError("too large"))
 
-        exit_code = main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "openai:gpt-5",
-            ]
-        )
+        exit_code = main(["input.txt", *_BASE_ARGS])
 
         assert exit_code == 5
         assert "too large" in capsys.readouterr().err
 
     def _invoke(self, mocker, exc):
         _patch_extract(mocker, side_effect=exc)
-        return main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-            ]
-        )
+        return main(["input.txt", *_BASE_ARGS])
 
     def test_url_fetch_error_returns_2(self, mocker, capsys):
         assert self._invoke(mocker, UrlFetchError("404")) == 2
@@ -403,158 +323,154 @@ class TestMainErrorCodes:
 
     def test_bad_schema_module_returns_1(self, capsys):
         exit_code = main(
-            [
-                "input.txt",
-                "--schema",
-                "definitely_not_a_real_module_xyz:Thing",
-                "--model",
-                "xai:grok-4.3",
-            ]
+            ["input.txt", "--schema", "definitely_not_a_real_module_xyz:Thing", "--model", "m"]
         )
         assert exit_code == 1
         assert "error" in capsys.readouterr().err.lower()
 
     def test_schema_not_basemodel_returns_1(self, capsys):
         exit_code = main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_NotASchema",
-                "--model",
-                "xai:grok-4.3",
-            ]
+            ["input.txt", "--schema", "tests.test_cli:_NotASchema", "--model", "xai:grok-4.3"]
         )
         assert exit_code == 1
         assert "BaseModel" in capsys.readouterr().err
 
 
 # ---------------------------------------------------------------------------
-# batch, usage, stdin
+# batch runs
 # ---------------------------------------------------------------------------
 
 
-class TestMainBatchAndUsage:
-    def test_multiple_files_use_extract_many(self, mocker, capsys):
-        fake = MagicMock()
-        fake.model_dump.return_value = {"name": "Ada", "age": 36}
-        mock_many = _patch_extract_many(mocker, return_value=[fake, fake])
+class TestMainBatch:
+    def test_multiple_files_stream_the_batch(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        mock_stream = _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
 
-        exit_code = main(
-            [
-                "a.pdf",
-                "b.pdf",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-            ]
-        )
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS])
 
         assert exit_code == 0
-        mock_many.assert_called_once()
-        captured = capsys.readouterr()
-        assert '"name": "Ada"' in captured.out
+        mock_stream.assert_called_once()
+        kwargs = mock_stream.call_args.kwargs
+        assert kwargs["max_concurrency"] == 5
+        assert kwargs["return_exceptions"] is False
+        assert kwargs["max_input_bytes"] == 50 * 1024 * 1024
+        assert kwargs["rich"] is False
+        assert kwargs["style"] is ExtractionStyle.DIRECT
+        payload = json.loads(capsys.readouterr().out)
+        assert payload == [{"name": "Ada", "age": 36}, {"name": "Ada", "age": 36}]
 
-    def test_batch_defaults_to_abort_on_first_failure(self, mocker):
-        fake = MagicMock()
-        fake.model_dump.return_value = {"name": "Ada", "age": 36}
-        mock_many = _patch_extract_many(mocker, return_value=[fake, fake])
+    def test_batch_array_output_is_input_ordered(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        linus = _FixtureSchema(name="Linus", age=54)
+        _patch_iter_extractions(mocker, events=[(1, linus), (0, ada)])
 
-        main(
-            [
-                "a.pdf",
-                "b.pdf",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-            ]
-        )
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS])
 
-        assert mock_many.call_args.kwargs["return_exceptions"] is False
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert [entry["name"] for entry in payload] == ["Ada", "Linus"]
 
-    def test_continue_on_error_passes_return_exceptions(self, mocker):
-        fake = MagicMock()
-        fake.model_dump.return_value = {"name": "Ada", "age": 36}
-        mock_many = _patch_extract_many(mocker, return_value=[fake, fake])
+    def test_max_concurrency_is_forwarded(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        mock_stream = _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
 
-        main(
-            [
-                "a.pdf",
-                "b.pdf",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--continue-on-error",
-            ]
-        )
+        main(["a.pdf", "b.pdf", *_BASE_ARGS, "--max-concurrency", "2"])
 
-        assert mock_many.call_args.kwargs["return_exceptions"] is True
+        assert mock_stream.call_args.kwargs["max_concurrency"] == 2
+        capsys.readouterr()
+
+    def test_continue_on_error_passes_return_exceptions(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        mock_stream = _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
+
+        main(["a.pdf", "b.pdf", *_BASE_ARGS, "--continue-on-error"])
+
+        assert mock_stream.call_args.kwargs["return_exceptions"] is True
+        capsys.readouterr()
 
     def test_continue_on_error_reports_failures_and_exits_7(self, mocker, capsys):
-        fake = MagicMock()
-        fake.model_dump.return_value = {"name": "Ada", "age": 36}
-        _patch_extract_many(mocker, return_value=[fake, ModelError("boom")])
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada), (1, ModelError("boom"))])
 
-        exit_code = main(
-            [
-                "a.pdf",
-                "b.pdf",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--continue-on-error",
-            ]
-        )
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--continue-on-error"])
 
         assert exit_code == 7
         captured = capsys.readouterr()
-        assert '"name": "Ada"' in captured.out  # the successful item is still emitted
-        assert '"error_type": "ModelError"' in captured.out
-        assert '"input": "b.pdf"' in captured.out
-        assert "warning:" not in captured.out
+        payload = json.loads(captured.out)
+        assert payload[0] == {"name": "Ada", "age": 36}
+        assert payload[1] == {"input": "b.pdf", "error": "boom", "error_type": "ModelError"}
         assert "1 of 2 input(s) failed" in captured.err
 
     def test_continue_on_error_all_success_exits_0(self, mocker, capsys):
-        fake = MagicMock()
-        fake.model_dump.return_value = {"name": "Ada", "age": 36}
-        _patch_extract_many(mocker, return_value=[fake, fake])
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
 
-        exit_code = main(
-            [
-                "a.pdf",
-                "b.pdf",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--continue-on-error",
-            ]
-        )
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--continue-on-error"])
 
         assert exit_code == 0
         assert capsys.readouterr().err == ""
 
-    def test_usage_flag_calls_extract_with_usage(self, mocker, capsys):
-        from openextract import Usage
+    def test_fail_fast_batch_maps_exit_code_and_keeps_stdout_empty(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada)], error=ModelError("upstream"))
 
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS])
+
+        assert exit_code == 4
+        captured = capsys.readouterr()
+        assert captured.out == ""
+        assert "upstream" in captured.err
+
+    def test_batch_repr_output(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--output", "repr"])
+
+        assert exit_code == 0
+        assert capsys.readouterr().out.startswith("[{'name': 'Ada'")
+
+    def test_batch_invalid_retry_values_return_1_before_any_model_call(self, mocker, capsys):
+        mock_stream = _patch_iter_extractions(mocker)
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--max-retries", "-1"])
+
+        assert exit_code == 1
+        assert "max_retries" in capsys.readouterr().err
+        mock_stream.assert_not_called()
+
+    def test_batch_invalid_max_concurrency_returns_1_before_any_model_call(self, mocker, capsys):
+        mock_stream = _patch_iter_extractions(mocker)
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--max-concurrency", "-2"])
+
+        assert exit_code == 1
+        assert "max_concurrency" in capsys.readouterr().err
+        mock_stream.assert_not_called()
+
+    def test_batch_invalid_max_input_bytes_returns_1(self, mocker, capsys):
+        mock_stream = _patch_iter_extractions(mocker)
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--max-input-bytes", "0"])
+
+        assert exit_code == 1
+        assert "max_input_bytes" in capsys.readouterr().err
+        mock_stream.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# usage output
+# ---------------------------------------------------------------------------
+
+
+class TestUsage:
+    def test_usage_flag_calls_extract_with_usage(self, mocker, capsys):
         fake = MagicMock()
         fake.model_dump.return_value = {"name": "Ada", "age": 36}
         usage = Usage(input_tokens=10, output_tokens=5, total_tokens=15)
         mock_usage = _patch_extract_with_usage(mocker, return_value=(fake, usage))
 
-        exit_code = main(
-            [
-                "input.txt",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--usage",
-            ]
-        )
+        exit_code = main(["input.txt", *_BASE_ARGS, "--usage"])
 
         assert exit_code == 0
         mock_usage.assert_called_once()
@@ -562,48 +478,280 @@ class TestMainBatchAndUsage:
         assert '"usage"' in captured.out
         assert captured.out.count("input_tokens") >= 1
 
-    def test_usage_with_multiple_inputs_returns_1(self, capsys):
-        exit_code = main(
-            [
-                "a.pdf",
-                "b.pdf",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--usage",
-            ]
-        )
-        assert exit_code == 1
-        assert "exactly one" in capsys.readouterr().err
+    def test_batch_usage_selects_rich_results(self, mocker, capsys):
+        ada = _rich_result(_FixtureSchema(name="Ada", age=36))
+        mock_stream = _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
 
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--usage"])
+
+        assert exit_code == 0
+        assert mock_stream.call_args.kwargs["rich"] is True
+        capsys.readouterr()
+
+    def test_batch_usage_reports_per_item_and_aggregate(self, mocker, capsys):
+        ada = _rich_result(_FixtureSchema(name="Ada", age=36), input_tokens=10, output_tokens=5)
+        linus = _rich_result(_FixtureSchema(name="Linus", age=54), input_tokens=2, output_tokens=1)
+        _patch_iter_extractions(mocker, events=[(0, ada), (1, linus)])
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--usage"])
+
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["results"][0] == {
+            "input": "a.pdf",
+            "result": {"name": "Ada", "age": 36},
+            "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+        }
+        assert payload["usage"] == {"input_tokens": 12, "output_tokens": 6, "total_tokens": 18}
+
+    def test_batch_usage_aggregates_successes_only_on_partial_failure(self, mocker, capsys):
+        ada = _rich_result(_FixtureSchema(name="Ada", age=36), input_tokens=10, output_tokens=5)
+        _patch_iter_extractions(mocker, events=[(0, ada), (1, ModelError("boom"))])
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--usage", "--continue-on-error"])
+
+        assert exit_code == 7
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["results"][1] == {
+            "input": "b.pdf",
+            "error": "boom",
+            "error_type": "ModelError",
+        }
+        assert payload["usage"] == {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+
+
+# ---------------------------------------------------------------------------
+# JSONL output
+# ---------------------------------------------------------------------------
+
+
+class TestJsonl:
+    def test_jsonl_streams_records_in_completion_order(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        linus = _FixtureSchema(name="Linus", age=54)
+        _patch_iter_extractions(mocker, events=[(1, linus), (0, ada)])
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--output", "jsonl"])
+
+        assert exit_code == 0
+        lines = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+        assert lines == [
+            {"index": 1, "input": "b.pdf", "result": {"name": "Linus", "age": 54}},
+            {"index": 0, "input": "a.pdf", "result": {"name": "Ada", "age": 36}},
+        ]
+
+    def test_jsonl_single_input_uses_batch_semantics(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada)])
+        mock_extract = _patch_extract(mocker)
+
+        exit_code = main(["a.pdf", *_BASE_ARGS, "--output", "jsonl"])
+
+        assert exit_code == 0
+        mock_extract.assert_not_called()
+        lines = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+        assert lines == [{"index": 0, "input": "a.pdf", "result": {"name": "Ada", "age": 36}}]
+
+    def test_jsonl_failure_records_preserve_input_identity(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada), (1, UrlFetchError("404"))])
+
+        exit_code = main(
+            ["a.pdf", "b.pdf", *_BASE_ARGS, "--output", "jsonl", "--continue-on-error"]
+        )
+
+        assert exit_code == 7
+        captured = capsys.readouterr()
+        lines = [json.loads(line) for line in captured.out.splitlines()]
+        assert lines[1] == {
+            "index": 1,
+            "input": "b.pdf",
+            "error": "404",
+            "error_type": "UrlFetchError",
+        }
+        assert "1 of 2 input(s) failed" in captured.err
+
+    def test_jsonl_usage_emits_per_item_usage_and_summary(self, mocker, capsys):
+        ada = _rich_result(_FixtureSchema(name="Ada", age=36), input_tokens=10, output_tokens=5)
+        _patch_iter_extractions(mocker, events=[(0, ada)])
+
+        exit_code = main(["a.pdf", *_BASE_ARGS, "--output", "jsonl", "--usage"])
+
+        assert exit_code == 0
+        lines = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+        assert lines[0]["usage"] == {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+        assert lines[1] == {
+            "summary": {
+                "inputs": 1,
+                "failed": 0,
+                "usage": {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+            }
+        }
+
+    def test_jsonl_without_usage_has_no_summary_line(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada)])
+
+        exit_code = main(["a.pdf", *_BASE_ARGS, "--output", "jsonl"])
+
+        assert exit_code == 0
+        lines = capsys.readouterr().out.splitlines()
+        assert len(lines) == 1
+        assert "summary" not in lines[0]
+
+    def test_jsonl_fail_fast_keeps_already_emitted_records(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada)], error=UrlFetchError("404"))
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--output", "jsonl"])
+
+        assert exit_code == 2
+        captured = capsys.readouterr()
+        assert json.loads(captured.out)["input"] == "a.pdf"
+        assert "404" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# progress reporting
+# ---------------------------------------------------------------------------
+
+
+class TestProgress:
+    def test_progress_reports_each_completion_on_stderr(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--progress"])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "progress: 1/2 completed (0 failed): a.pdf" in captured.err
+        assert "progress: 2/2 completed (0 failed): b.pdf" in captured.err
+        assert "progress" not in captured.out
+
+    def test_progress_counts_failures(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ModelError("boom")), (1, ada)])
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--progress", "--continue-on-error"])
+
+        assert exit_code == 7
+        assert "progress: 1/2 completed (1 failed): a.pdf" in capsys.readouterr().err
+
+    def test_no_progress_lines_by_default(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
+
+        main(["a.pdf", "b.pdf", *_BASE_ARGS])
+
+        assert "progress" not in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# manifest input
+# ---------------------------------------------------------------------------
+
+
+class TestManifest:
+    def _write_manifest(self, tmp_path, lines):
+        path = tmp_path / "manifest.jsonl"
+        path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return str(path)
+
+    def test_manifest_builds_extraction_inputs_and_labels(self, mocker, capsys, tmp_path):
+        manifest = self._write_manifest(
+            tmp_path,
+            [
+                '{"source": "a.pdf", "media_type": "application/pdf", "name": "invoice-a"}',
+                "",
+                '{"source": "b.txt"}',
+            ],
+        )
+        ada = _FixtureSchema(name="Ada", age=36)
+        mock_stream = _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
+
+        exit_code = main([*_BASE_ARGS, "--manifest", manifest, "--output", "jsonl"])
+
+        assert exit_code == 0
+        items = mock_stream.call_args.args[2]
+        assert items == [
+            ExtractionInput(source="a.pdf", media_type="application/pdf", name="invoice-a"),
+            ExtractionInput(source="b.txt", media_type=None, name=None),
+        ]
+        lines = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+        assert [line["input"] for line in lines] == ["invoice-a", "b.txt"]
+
+    def test_manifest_single_entry_still_uses_batch_output(self, mocker, capsys, tmp_path):
+        manifest = self._write_manifest(tmp_path, ['{"source": "a.pdf"}'])
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada)])
+
+        exit_code = main([*_BASE_ARGS, "--manifest", manifest])
+
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload == [{"name": "Ada", "age": 36}]
+
+    def test_manifest_with_positional_inputs_returns_1(self, capsys, tmp_path):
+        manifest = self._write_manifest(tmp_path, ['{"source": "a.pdf"}'])
+
+        exit_code = main(["other.pdf", *_BASE_ARGS, "--manifest", manifest])
+
+        assert exit_code == 1
+        assert "cannot be combined" in capsys.readouterr().err
+
+    def test_manifest_missing_file_returns_1(self, capsys, tmp_path):
+        exit_code = main([*_BASE_ARGS, "--manifest", str(tmp_path / "missing.jsonl")])
+
+        assert exit_code == 1
+        assert "cannot read manifest" in capsys.readouterr().err
+
+    def test_manifest_without_entries_returns_1(self, capsys, tmp_path):
+        manifest = self._write_manifest(tmp_path, ["", "   "])
+
+        exit_code = main([*_BASE_ARGS, "--manifest", manifest])
+
+        assert exit_code == 1
+        assert "contains no entries" in capsys.readouterr().err
+
+    @pytest.mark.parametrize(
+        ("line", "message"),
+        [
+            ("not json", "invalid JSON"),
+            ('["a.pdf"]', "expected a JSON object"),
+            ('{"source": "a.pdf", "mediatype": "text/plain"}', "unknown keys: mediatype"),
+            ('{"media_type": "text/plain"}', "'source' must be a non-empty string"),
+            ('{"source": ""}', "'source' must be a non-empty string"),
+            ('{"source": "-"}', "stdin (-) is not supported"),
+            ('{"source": "a.pdf", "media_type": 7}', "'media_type' must be a string"),
+            ('{"source": "a.pdf", "name": 7}', "'name' must be a string"),
+        ],
+    )
+    def test_manifest_invalid_entries_return_1(self, capsys, tmp_path, line, message):
+        manifest = self._write_manifest(tmp_path, [line])
+
+        exit_code = main([*_BASE_ARGS, "--manifest", manifest])
+
+        assert exit_code == 1
+        error = capsys.readouterr().err
+        assert "manifest line 1" in error
+        assert message in error
+
+
+# ---------------------------------------------------------------------------
+# stdin
+# ---------------------------------------------------------------------------
+
+
+class TestStdin:
     def test_stdin_without_media_type_returns_1(self, capsys, mocker):
         mocker.patch("sys.stdin")
-        exit_code = main(
-            [
-                "-",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-            ]
-        )
+        exit_code = main(["-", *_BASE_ARGS])
         assert exit_code == 1
         assert "media-type" in capsys.readouterr().err.lower()
 
     def test_stdin_with_other_paths_returns_1(self, capsys):
-        exit_code = main(
-            [
-                "-",
-                "other.pdf",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--media-type",
-                "application/pdf",
-            ]
-        )
+        exit_code = main(["-", "other.pdf", *_BASE_ARGS, "--media-type", "application/pdf"])
         assert exit_code == 1
         assert "stdin" in capsys.readouterr().err.lower()
 
@@ -613,19 +761,67 @@ class TestMainBatchAndUsage:
         mock_extract = _patch_extract(mocker, return_value=fake)
         stdin = mocker.patch("openextract._cli.sys.stdin")
 
-        exit_code = main(
-            [
-                "-",
-                "--schema",
-                "tests.test_cli:_FixtureSchema",
-                "--model",
-                "xai:grok-4.3",
-                "--media-type",
-                "application/pdf",
-            ]
-        )
+        exit_code = main(["-", *_BASE_ARGS, "--media-type", "application/pdf"])
 
         assert exit_code == 0
         assert mock_extract.call_args.kwargs["input_file"] is stdin.buffer
         assert mock_extract.call_args.kwargs["media_type"] == "application/pdf"
         stdin.buffer.read.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# cancellation and broken pipes
+# ---------------------------------------------------------------------------
+
+
+class TestInterruptAndBrokenPipe:
+    def test_single_keyboard_interrupt_returns_130(self, mocker, capsys):
+        _patch_extract(mocker, side_effect=KeyboardInterrupt)
+
+        exit_code = main(["input.txt", *_BASE_ARGS])
+
+        assert exit_code == 130
+        assert "interrupted" in capsys.readouterr().err
+
+    def test_batch_keyboard_interrupt_returns_130(self, mocker, capsys):
+        _patch_iter_extractions(mocker, error=KeyboardInterrupt())
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS])
+
+        assert exit_code == 130
+        assert "interrupted" in capsys.readouterr().err
+
+    def test_single_broken_pipe_returns_141(self, mocker, capsys):
+        _patch_extract(mocker, return_value=_FixtureSchema(name="Ada", age=36))
+        mocker.patch("openextract._cli._print_json", side_effect=BrokenPipeError)
+        discard = mocker.patch("openextract._cli._discard_stdout")
+
+        exit_code = main(["input.txt", *_BASE_ARGS, "--output", "repr"])
+
+        assert exit_code == 141
+        discard.assert_called_once_with()
+        capsys.readouterr()
+
+    def test_jsonl_broken_pipe_returns_141(self, mocker, capsys):
+        ada = _FixtureSchema(name="Ada", age=36)
+        _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
+        mocker.patch("openextract._cli._emit_json_line", side_effect=BrokenPipeError)
+        discard = mocker.patch("openextract._cli._discard_stdout")
+
+        exit_code = main(["a.pdf", "b.pdf", *_BASE_ARGS, "--output", "jsonl"])
+
+        assert exit_code == 141
+        discard.assert_called_once_with()
+        capsys.readouterr()
+
+    def test_discard_stdout_redirects_to_devnull(self, monkeypatch, tmp_path):
+        target = tmp_path / "captured.txt"
+        with open(target, "w", encoding="utf-8") as handle:
+            monkeypatch.setattr(sys, "stdout", handle)
+            _discard_stdout()
+            print("lost after redirect")
+        assert target.read_text(encoding="utf-8") == ""
+
+    def test_discard_stdout_tolerates_stdout_without_fileno(self, monkeypatch):
+        monkeypatch.setattr(sys, "stdout", io.StringIO())
+        _discard_stdout()  # must not raise


### PR DESCRIPTION
Closes #164.

Routes all CLI batch runs through the library's streaming extraction iterator so incremental output, progress, and buffered array output share one code path.

## What's new

- `--max-concurrency N` bounds in-flight extractions (default 5), validated before any model call alongside retry and size options.
- `--output jsonl` writes one record per completed input, flushed immediately in completion order; each line carries `index` and `input` so consumers can reorder or join back to their inputs. Large batches emit useful output long before the run finishes.
- `--progress` reports per-item completion on stderr only, keeping stdout machine-readable.
- `--manifest FILE` reads inputs from a JSONL file with per-item `source`, `media_type`, and `name`, enabling heterogeneous batches; entries become `ExtractionInput` items and invalid manifests exit 1 before any model call.
- `--usage` now works on batches through the rich result API, reporting per-item usage plus an aggregate (JSON object shape for arrays, per-record fields plus a final `summary` line for JSONL).

## Contracts

The default JSON array output, its input ordering, and exit codes 0-7 are unchanged. Partial failures keep input identity in `{"input", "error", "error_type"}` records. Ctrl-C cancels outstanding work and exits 130; a stdout consumer closing early (e.g. `| head`) exits 141 silently. All of this is documented in `docs/cli.md` and the README.

## Tests

CLI test suite rewritten around the streaming batch path: manifests, JSONL ordering and summary lines, progress format, usage aggregation, fail-fast semantics, interrupts, and broken pipes, keeping the repo at 100% branch coverage.