### PR TITLE
release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ timing when that is known.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-08-20
+
 ### Added
 - CLI swarm and agent flags: `--swarm N`, `--models a,b`, `--agent SPEC`,
   `--agents SPEC,SPEC`, and `--reduce merge|vote|first`. `--schema` is now

--- a/docs/index.html
+++ b/docs/index.html
@@ -281,10 +281,10 @@ title: openextract
           <div class="flex items-baseline justify-between mb-8 sm:mb-10 flex-wrap gap-3">
             <div>
               <p class="font-mono text-[11px] text-black/40 uppercase tracking-wider mb-2">What&rsquo;s new</p>
-              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">On main</h2>
-              <p class="text-sm text-black/40 mt-2">Unreleased on GitHub. Latest PyPI release is <span class="font-mono">v0.10.0</span>.</p>
+              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">In v0.11.0</h2>
+              <p class="text-sm text-black/40 mt-2">The latest PyPI release: <span class="font-mono">v0.11.0</span>.</p>
             </div>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#unreleased" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#0110---2026-08-20" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
               Full changelog <i data-lucide="arrow-up-right" class="w-3 h-3"></i>
             </a>
           </div>
@@ -293,17 +293,17 @@ title: openextract
             <div class="p-6 border border-black/10 bg-white">
               <div class="flex items-center gap-3 mb-3">
                 <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="repeat" class="w-4 h-4 text-black/40"></i>
+                  <i data-lucide="network" class="w-4 h-4 text-black/40"></i>
                 </div>
-                <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">Sessions</span>
+                <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">Swarms</span>
               </div>
-              <h3 class="font-mono text-base font-medium text-black/90 mb-2">Reusable extractors</h3>
+              <h3 class="font-mono text-base font-medium text-black/90 mb-2">Swarms and agents</h3>
               <p class="text-sm text-black/60 leading-relaxed mb-4">
-                <code class="font-mono text-black/90 text-xs">Extractor</code> and <code class="font-mono text-black/90 text-xs">AsyncExtractor</code> build one agent, reuse HTTP clients, and close them on exit.
+                <code class="font-mono text-black/90 text-xs">extract_swarm</code> runs several agents over one input and reduces their outputs; <code class="font-mono text-black/90 text-xs">define_agent</code> packages a specialist you can import, compose, or serve over HTTP.
               </p>
               <div class="flex flex-wrap gap-1.5">
-                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">Extractor</span>
-                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">RetryPolicy</span>
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">extract_swarm</span>
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">define_agent</span>
               </div>
             </div>
 
@@ -328,23 +328,24 @@ title: openextract
             <div class="p-6 border border-black/10 bg-white">
               <div class="flex items-center gap-3 mb-3">
                 <div class="w-9 h-9 border border-black/10 flex items-center justify-center">
-                  <i data-lucide="layers" class="w-4 h-4 text-black/40"></i>
+                  <i data-lucide="terminal" class="w-4 h-4 text-black/40"></i>
                 </div>
-                <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">Contracts</span>
+                <span class="font-mono text-[10px] text-black/40 uppercase tracking-wider">CLI</span>
               </div>
-              <h3 class="font-mono text-base font-medium text-black/90 mb-2">Typed inputs and results</h3>
+              <h3 class="font-mono text-base font-medium text-black/90 mb-2">Batch-ready CLI</h3>
               <p class="text-sm text-black/60 leading-relaxed mb-4">
-                Per-item media types, streaming batch yields, and <code class="font-mono text-black/90 text-xs">ExtractionResult</code> diagnostics without retaining raw media.
+                Incremental <code class="font-mono text-black/90 text-xs">--output jsonl</code>, <code class="font-mono text-black/90 text-xs">--manifest</code> per-input media types, progress on stderr, and <code class="font-mono text-black/90 text-xs">--swarm</code> / <code class="font-mono text-black/90 text-xs">--agent</code> from the shell.
               </p>
               <div class="flex flex-wrap gap-1.5">
-                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">ExtractionInput</span>
-                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">streaming</span>
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">jsonl</span>
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">manifest</span>
+                <span class="font-mono text-[11px] text-black/90 border border-black/10 px-2 py-1">swarm</span>
               </div>
             </div>
           </div>
 
           <p class="font-mono text-xs text-black/40">
-            Also on main: 50&nbsp;MiB input caps, OpenAI Responses by default, ExtractBench for any model.
+            Also in v0.11.0: reusable <code>Extractor</code> sessions, typed input/result contracts, 50&nbsp;MiB input caps, ExtractBench for any model.
             <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#0100---2026-08-01" class="hover:text-black/90 transition-colors">v0.10.0</a>
             shipped non-blocking async I/O and transient-only retries.
           </p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.10.0"
+version = "0.11.0"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 
 [options]
@@ -1229,7 +1229,7 @@ wheels = [
 
 [[package]]
 name = "openextract"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Cut the 0.11.0 release: bump the package version, date the changelog section, and point the docs landing page's what's-new section at the release.

Headlines since 0.10.0: swarms and importable/remote agents (`extract_swarm`, `define_agent`, `define_remote_agent`, exit code 8), agent-aware one-shot extract APIs, extraction styles (`direct`/`search`/`code`), typed input/result contracts with per-item media types, reusable `Extractor`/`AsyncExtractor` sessions, the batch-workflow CLI (`--output jsonl`, `--manifest`, `--progress`, `--max-concurrency`, swarm flags), and the internals modularization.

Merging to `main` with green CI triggers the release workflow, which publishes `openextract 0.11.0` to PyPI and creates the `v0.11.0` GitHub release.