### PR TITLE
perf(ci): cut CI wall-clock time roughly in half

### DIFF
--- a/.github/actions/detect-jobs/action.yml
+++ b/.github/actions/detect-jobs/action.yml
@@ -1,0 +1,27 @@
+name: Detect required jobs
+description: >-
+  Decide which CI checks the current change set actually requires. Runs inside
+  each CI job instead of as a gating job of its own, so no job waits on a
+  separate runner before it can start work.
+
+outputs:
+  lint:
+    description: "true when lint and type checks must run"
+    value: ${{ steps.filter.outputs.lint }}
+  test:
+    description: "true when the test suite must run"
+    value: ${{ steps.filter.outputs.test }}
+  package:
+    description: "true when distribution builds must run"
+    value: ${{ steps.filter.outputs.package }}
+
+runs:
+  using: composite
+  steps:
+    - id: filter
+      shell: bash
+      env:
+        EVENT_NAME: ${{ github.event_name }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+        HEAD_SHA: ${{ github.sha }}
+      run: python3 scripts/ci_needed.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,56 +15,45 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  UV_FROZEN: "1"
+  UV_NO_PROGRESS: "1"
+
+# Every job detects for itself whether the change set requires it (via the
+# .github/actions/detect-jobs composite action) and skips its own work when it
+# does not. Nothing waits on a gating job, so lint, test, and package all start
+# the moment the run is created.
 jobs:
-  changes:
-    name: Detect changes
+  lint:
     runs-on: ubuntu-latest
-    timeout-minutes: 3
-    outputs:
-      lint: ${{ steps.filter.outputs.lint }}
-      test: ${{ steps.filter.outputs.test }}
-      package: ${{ steps.filter.outputs.package }}
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Detect required jobs
-        id: filter
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
-          HEAD_SHA: ${{ github.sha }}
-        run: python3 scripts/ci_needed.py
-
-  lint:
-    needs: changes
-    if: needs.changes.outputs.lint == 'true'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    env:
-      UV_FROZEN: "1"
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-        with:
-          persist-credentials: false
+      - id: filter
+        uses: ./.github/actions/detect-jobs
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
+        if: steps.filter.outputs.lint == 'true'
         with:
           enable-cache: true
-      - run: uv sync --dev
-      - run: uv run --no-sync ruff check .
-      - run: uv run --no-sync ruff format --check .
-      - run: uv run --no-sync ty check
-      - run: uv run --no-sync python scripts/check_api_reference.py
+          cache-dependency-glob: uv.lock
+      - if: steps.filter.outputs.lint == 'true'
+        run: uv sync --dev
+      - if: steps.filter.outputs.lint == 'true'
+        run: uv run --no-sync ruff check .
+      - if: steps.filter.outputs.lint == 'true'
+        run: uv run --no-sync ruff format --check .
+      - if: steps.filter.outputs.lint == 'true'
+        run: uv run --no-sync ty check
+      - if: steps.filter.outputs.lint == 'true'
+        run: uv run --no-sync python scripts/check_api_reference.py
 
   test:
     name: Test (Python ${{ matrix.python-version }})
-    needs: changes
-    if: needs.changes.outputs.test == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    env:
-      UV_FROZEN: "1"
     strategy:
       fail-fast: false
       matrix:
@@ -76,81 +65,79 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
+          fetch-depth: 0
           persist-credentials: false
+      - id: filter
+        uses: ./.github/actions/detect-jobs
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
+        if: steps.filter.outputs.test == 'true'
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
-      - run: uv sync --dev
+          cache-dependency-glob: uv.lock
+      - if: steps.filter.outputs.test == 'true'
+        run: uv sync --dev
+      # -n auto fans the suite across every runner core; coverage is combined
+      # from the workers and enforced in the same process.
       - name: Run tests with coverage
-        if: matrix.coverage
-        run: uv run --no-sync pytest -v --cov=openextract --cov-report=term-missing --cov-fail-under=0
-      - name: Check coverage threshold
-        if: matrix.coverage
-        run: uv run --no-sync coverage report --fail-under=100
+        if: ${{ steps.filter.outputs.test == 'true' && matrix.coverage }}
+        run: >-
+          uv run --no-sync pytest -n auto
+          --cov=openextract --cov-report=term-missing --cov-fail-under=100
       - name: Run tests
-        if: ${{ !matrix.coverage }}
-        run: uv run --no-sync pytest -v
+        if: ${{ steps.filter.outputs.test == 'true' && !matrix.coverage }}
+        run: uv run --no-sync pytest -n auto
 
   package:
     name: Build and install distributions
-    needs: changes
-    if: needs.changes.outputs.package == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
+          fetch-depth: 0
           persist-credentials: false
+      - id: filter
+        uses: ./.github/actions/detect-jobs
       - uses: astral-sh/setup-uv@38f3f104447c67c051c4a08e39b64a148898af3a  # v4.2.0
+        if: steps.filter.outputs.package == 'true'
         with:
           python-version: "3.12"
           enable-cache: true
-      - run: uv build
-      - name: Smoke-test wheel
+          cache-dependency-glob: uv.lock
+      - if: steps.filter.outputs.package == 'true'
+        run: uv build
+      - name: Smoke-test wheel and source distribution
+        if: steps.filter.outputs.package == 'true'
         run: |
           uv venv .venv-wheel
-          uv pip install --python .venv-wheel/bin/python dist/*.whl
-          .venv-wheel/bin/python -c "import openextract; assert callable(openextract.extract)"
-          .venv-wheel/bin/openextract --help
-      - name: Smoke-test source distribution
-        run: |
           uv venv .venv-sdist
+          uv pip install --python .venv-wheel/bin/python dist/*.whl
           uv pip install --python .venv-sdist/bin/python dist/*.tar.gz
-          .venv-sdist/bin/python -c "import openextract; assert callable(openextract.extract)"
-          .venv-sdist/bin/openextract --help
+          for venv in .venv-wheel .venv-sdist; do
+            "$venv/bin/python" -c "import openextract; assert callable(openextract.extract)"
+            "$venv/bin/openextract" --help
+          done
 
   ci:
     name: CI
-    needs: [changes, lint, test, package]
+    needs: [lint, test, package]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - name: Check required jobs
         env:
-          CHANGES: ${{ needs.changes.result }}
           LINT: ${{ needs.lint.result }}
           TEST: ${{ needs.test.result }}
           PACKAGE: ${{ needs.package.result }}
         run: |
-          python3 - <<'PY'
-          import os
-          import sys
-
-          results = {
-              "changes": os.environ["CHANGES"],
-              "lint": os.environ["LINT"],
-              "test": os.environ["TEST"],
-              "package": os.environ["PACKAGE"],
-          }
-          allowed = {"success", "skipped"}
-          failed = [name for name, result in results.items() if result not in allowed]
-          print("job results:", results)
-          if results["changes"] != "success":
-              print("Change detection must succeed")
-              sys.exit(1)
-          if failed:
-              print("Failed jobs:", ", ".join(failed))
-              sys.exit(1)
-          PY
+          echo "job results: lint=$LINT test=$TEST package=$PACKAGE"
+          status=0
+          for entry in "lint:$LINT" "test:$TEST" "package:$PACKAGE"; do
+            if [ "${entry#*:}" != "success" ]; then
+              echo "Job did not succeed: ${entry%%:*} (${entry#*:})"
+              status=1
+            fi
+          done
+          exit "$status"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,14 +18,15 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Build is read-only, so it only needs to serialize against itself per ref.
+    # Superseded pull-request builds are cancelled instead of queued.
+    concurrency:
+      group: pages-build-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: ${{ github.event_name == 'pull_request' }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
@@ -46,6 +47,11 @@ jobs:
   deploy:
     if: github.event_name != 'pull_request'
     needs: build
+    # Pages allows one deployment at a time; queue rather than cancel so a
+    # merged commit is never dropped.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ timing when that is known.
 
 ## [Unreleased]
 
+### Changed
+- CI wall-clock time roughly halved. Change detection moved out of a gating job
+  into the `.github/actions/detect-jobs` composite action that each job runs for
+  itself, so lint, test, and package now start immediately instead of waiting on
+  a separate runner. The test suite runs under `pytest -n auto` (new
+  `pytest-xdist` dev dependency), and the coverage threshold is enforced by the
+  same pytest process rather than a follow-up `coverage report` step.
+- The docs workflow no longer serializes pull-request builds behind a global
+  `pages` concurrency group; only the deploy job queues on `pages`, and
+  superseded pull-request doc builds are cancelled.
+
 ## [0.11.0] - 2026-08-20
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Thanks for your interest in contributing to openextract!
    uv sync --dev
    ```
 
-3. Run tests:
+3. Run tests (add `-n auto` to fan them across cores, as CI does):
    ```bash
    uv run pytest
    ```
@@ -60,9 +60,14 @@ uv run ty check
 ## CI
 
 GitHub Actions (`.github/workflows/ci.yml`) runs lint, tests, and package smoke
-tests. Jobs that a change set cannot affect are skipped (for example a
-docs-only PR does not install Python dependencies). Outdated pull-request runs
-are cancelled when a new commit is pushed. After CI succeeds on `main`,
+tests. All three start in parallel the moment a run is created; each one calls
+the `.github/actions/detect-jobs` composite action first and skips its own work
+when the change set cannot affect it (for example a docs-only PR does not
+install Python dependencies). Nothing waits on a gating job, and the test suite
+runs under `pytest -n auto` across every runner core. The single required check
+is the `CI` job, which fails unless lint, test, and package all succeeded.
+Outdated pull-request runs are cancelled when a new commit is pushed. After CI
+succeeds on `main`,
 [`.github/workflows/release.yml`](.github/workflows/release.yml) publishes to
 PyPI only when the version in `pyproject.toml` is new.
 
@@ -137,8 +142,7 @@ CI is green — [`.github/workflows/release.yml`](.github/workflows/release.yml)
    uv run ruff check .
    uv run ruff format --check .
    uv run ty check
-   uv run pytest -v --cov=openextract --cov-report=term-missing
-   uv run coverage report --fail-under=100
+   uv run pytest -n auto --cov=openextract --cov-report=term-missing --cov-fail-under=100
    ```
 5. **Dependency embargo** — confirm `[tool.uv] exclude-newer` is within the
    rolling 24h window (merge recent `embargo-bump` PRs from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
     "pytest-mock>=3.15.1",
+    "pytest-xdist>=3.8.0",
     "ruff>=0.14.10",
     "ty>=0.0.35",
     "pydantic-ai-slim[anthropic,bedrock,cohere,google,groq,huggingface,logfire,mistral,openai,openrouter,xai]>=1.37.0",

--- a/scripts/ci_needed.py
+++ b/scripts/ci_needed.py
@@ -11,6 +11,7 @@ from pathlib import Path
 ALWAYS_ALL = frozenset(
     {
         ".github/workflows/ci.yml",
+        ".github/actions/detect-jobs/action.yml",
         "pyproject.toml",
         "uv.lock",
         ".python-version",

--- a/uv.lock
+++ b/uv.lock
@@ -543,6 +543,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1283,6 +1292,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -1315,6 +1325,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "ruff", specifier = ">=0.14.10" },
     { name = "ty", specifier = ">=0.0.35" },
 ]
@@ -1819,6 +1830,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Change detection no longer runs as a gating job. It moves into the
.github/actions/detect-jobs composite action that lint, test, and package
each run for themselves, so all three start the moment a run is created
instead of waiting on a separate runner to provision, check out, diff, and
hand off outputs. That serial prefix was ~10s of every run.

Tests now run under pytest -n auto (new pytest-xdist dev dependency),
which takes the 714-test suite from ~17s to ~8s on a 4-core runner with
coverage still at 100%. The coverage threshold is enforced by the same
pytest process via --cov-fail-under=100 rather than a follow-up
`coverage report` invocation, and the two package smoke tests share one
step.

The docs workflow no longer puts every build behind a single global
`pages` concurrency group, which serialized unrelated pull-request doc
builds against each other and against deploys. Only the deploy job queues
on `pages` now; superseded pull-request builds are cancelled.

The required check is still the `CI` gate job, which now fails unless
lint, test, and package all report success.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01U1brW3Z2MKD7nWcHE1RG46