### PR TITLE
Make windowed parse-then-extract usable on the 6-doc GLM smoke

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ timing when that is known.
 
 ### Changed
 - Parse-then-extract windows page-indexed PDF text under a 12k-character
-  budget (was 80k) and splits a single oversized page so each model call fits
-  GLM-class context. ExtractBench extracts windows in a bounded thread pool
+  budget (was 80k) and at most 4 pages, and splits a single oversized page so
+  each model call fits GLM-class context. Slide decks that fit 80k as one
+  prompt (Veralto) now split. ExtractBench extracts windows in a bounded thread pool
   (`--window-concurrency`, default 4) with a per-call timeout (`--timeout`,
   default 240s) and collects citations from every window before reduce, so
   Bianco-class docs keep page cites. Token-limit errors are permanent and are

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ timing when that is known.
   each model call fits GLM-class context. Slide decks that fit 80k as one
   prompt (Veralto) now split. ExtractBench extracts windows in a bounded thread pool
   (`--window-concurrency`, default 4) with a per-call timeout (`--timeout`,
-  default 240s) and collects citations from every window before reduce, so
-  Bianco-class docs keep page cites. Token-limit errors are permanent and are
-  not retried. Bounding boxes remain parser-backed only.
+  default 240s). Window attempts are not retried; request timeouts and
+  token-limit errors are permanent so ExtractBench does not burn its 1800s
+  per-file limit three times (pueblo / long). Citations are collected from
+  every window before reduce, then missing pages are backfilled from parse
+  values (including ``1,234`` / ``1234.0`` forms) so Bianco-class docs still
+  emit `field_citations` when the model returns an empty cite list. Bounding
+  boxes remain parser-backed only.
 - PDF parse takes a process-wide lock. pypdfium2 is not thread-safe; concurrent
   ExtractBench workers no longer crash native PDFium.
 - Usage capture asks OpenRouter for native usage via both `openrouter_usage`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,19 @@ timing when that is known.
 ## [Unreleased]
 
 ### Changed
-- Parse-then-extract now chunks page-indexed PDF text by a character budget
-  instead of dumping the whole document into one prompt. Each window is
-  extracted and merged with the existing reduce strategy. A single window still
-  uses the one-shot `_extract_once` path so existing retry tests keep working.
-  ExtractBench uses the same windowed path; `--cite` stays on by default.
-  Bounding boxes remain parser-backed only.
-- Usage capture skips default-zero `input_tokens` so OpenRouter
-  `request_tokens` / `prompt_tokens` (including nested `details`) populate
-  `extract_with_usage` instead of reporting `0` tokens / `$0`.
+- Parse-then-extract windows page-indexed PDF text under a 12k-character
+  budget (was 80k) and splits a single oversized page so each model call fits
+  GLM-class context. ExtractBench extracts windows in a bounded thread pool
+  (`--window-concurrency`, default 4) with a per-call timeout (`--timeout`,
+  default 240s) and collects citations from every window before reduce, so
+  Bianco-class docs keep page cites. Token-limit errors are permanent and are
+  not retried. Bounding boxes remain parser-backed only.
+- PDF parse takes a process-wide lock. pypdfium2 is not thread-safe; concurrent
+  ExtractBench workers no longer crash native PDFium.
+- Usage capture asks OpenRouter for native usage via both `openrouter_usage`
+  and `extra_body.usage`, then reads `prompt_tokens` / `native_tokens_*` from
+  `result.usage`, nested `details`, `response`, and `all_messages`. Default-zero
+  pydantic-ai `input_tokens` is still skipped. Counts are never invented.
 
 ## [0.12.0] - 2026-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ timing when that is known.
 
 ### Changed
 - Parse-then-extract windows page-indexed PDF text under a 12k-character
-  budget (was 80k) and at most 4 pages, and splits a single oversized page so
+  budget (was 80k) and one page per window, and splits a single oversized page so
   each model call fits GLM-class context. Slide decks that fit 80k as one
   prompt (Veralto) now split. ExtractBench extracts windows in a bounded thread pool
   (`--window-concurrency`, default 4) with a per-call timeout (`--timeout`,

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -86,10 +86,12 @@ with `--no-cite`) and maps them onto ExtractBench `FieldCitation`:
 
 The runner **parses PDFs locally** (pypdfium2, `openextract[pdf]` / `openextract[all]`)
 and feeds page-indexed text (`--- Page N ---`) to the model before extraction.
-Long documents are split into page windows under a character budget, extracted
-per window, and merged — the whole PDF is not dumped as one prompt. That is the
-default path so page and word F1 can move on a 6-document `--test` smoke without
-blowing the model context. Boxes are never invented and are never taken from the
+Long documents (and oversized pages) are split into windows under a 12k-character
+budget, extracted with bounded concurrency (`--window-concurrency`, default 4),
+and merged — the whole PDF is not dumped as one prompt. Each model call uses
+`--timeout` (default 240s) so a doomed window fails fast instead of burning
+ExtractBench's 1800s per-file limit three times. Citations are collected from
+every window before reduce. Boxes are never invented and are never taken from the
 model: if a parser span matches the quote (exact, then simple fuzzy), a
 normalized COCO `[x, y, width, height]` in `[0, 1]` is attached; if nothing
 matches, `bbox` is omitted. Citations without a page cannot become
@@ -98,7 +100,8 @@ mapping step.
 
 `--no-cite` still runs parse-then-extract but does not ask for or emit
 `field_citations`. Token `usage` and `cost_usd` come from the provider usage
-object captured by `extract_with_usage`.
+object captured by `extract_with_usage` (OpenRouter native usage is requested
+via `extra_body` as well as `openrouter_usage`).
 
 `--test` is 6 documents and is the right first run (cents on a hosted API). A
 full run is 370 documents / 4,869 pages and is metered API usage.

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -90,11 +90,14 @@ Long documents (and oversized pages) are split into windows under a 12k-characte
 / 1-page budget, extracted with bounded concurrency (`--window-concurrency`, default 4),
 and merged — the whole PDF is not dumped as one prompt. Each model call uses
 `--timeout` (default 240s) so a doomed window fails fast instead of burning
-ExtractBench's 1800s per-file limit three times. Citations are collected from
-every window before reduce. Boxes are never invented and are never taken from the
-model: if a parser span matches the quote (exact, then simple fuzzy), a
-normalized COCO `[x, y, width, height]` in `[0, 1]` is attached; if nothing
-matches, `bbox` is omitted. Citations without a page cannot become
+ExtractBench's 1800s per-file limit three times. Window calls are a single
+attempt; request timeouts and token-limit errors are not retried at file
+level. Citations are collected from every window before reduce. When a window
+returns values but no cites, pages are backfilled from the local parse
+(including numeric display variants). Boxes are never invented and are never
+taken from the model: if a parser span matches the quote (exact, then simple
+fuzzy), a normalized COCO `[x, y, width, height]` in `[0, 1]` is attached; if
+nothing matches, `bbox` is omitted. Citations without a page cannot become
 `FieldCitation` (ExtractBench requires `page >= 1`) and are dropped at the
 mapping step.
 

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -87,7 +87,7 @@ with `--no-cite`) and maps them onto ExtractBench `FieldCitation`:
 The runner **parses PDFs locally** (pypdfium2, `openextract[pdf]` / `openextract[all]`)
 and feeds page-indexed text (`--- Page N ---`) to the model before extraction.
 Long documents (and oversized pages) are split into windows under a 12k-character
-/ 4-page budget, extracted with bounded concurrency (`--window-concurrency`, default 4),
+/ 1-page budget, extracted with bounded concurrency (`--window-concurrency`, default 4),
 and merged — the whole PDF is not dumped as one prompt. Each model call uses
 `--timeout` (default 240s) so a doomed window fails fast instead of burning
 ExtractBench's 1800s per-file limit three times. Citations are collected from

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -87,7 +87,7 @@ with `--no-cite`) and maps them onto ExtractBench `FieldCitation`:
 The runner **parses PDFs locally** (pypdfium2, `openextract[pdf]` / `openextract[all]`)
 and feeds page-indexed text (`--- Page N ---`) to the model before extraction.
 Long documents (and oversized pages) are split into windows under a 12k-character
-budget, extracted with bounded concurrency (`--window-concurrency`, default 4),
+/ 4-page budget, extracted with bounded concurrency (`--window-concurrency`, default 4),
 and merged — the whole PDF is not dumped as one prompt. Each model call uses
 `--timeout` (default 240s) so a doomed window fails fast instead of burning
 ExtractBench's 1800s per-file limit three times. Citations are collected from

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -21,6 +21,7 @@ import os
 import re
 import subprocess
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +30,7 @@ from pydantic import BaseModel, ConfigDict
 
 from openextract import (
     Citation,
+    ExtractionError,
     Extractor,
     InputTooLargeError,
     ModelError,
@@ -67,6 +69,8 @@ DEFAULT_INSTRUCTIONS = (
     "return an empty list when rows are present."
 )
 DEFAULT_MAX_INPUT_BYTES = 500 * 1024 * 1024
+DEFAULT_CALL_TIMEOUT = 240.0
+DEFAULT_WINDOW_CONCURRENCY = 4
 _REF_PREFIXES = ("#/$defs/", "#/definitions/")
 
 
@@ -202,12 +206,22 @@ def _output_type_for_schema(schema: dict[str, Any], model: str | object) -> obje
     return output_type
 
 
-def _build_schema_agent(model: str | object, schema: dict[str, Any], instructions: str):
+def _build_schema_agent(
+    model: str | object,
+    schema: dict[str, Any],
+    instructions: str,
+    *,
+    timeout: float | None = None,
+):
     from pydantic_ai import Agent
 
     output_type = _output_type_for_schema(schema, model)
     routed = _route_model(model) if isinstance(model, str) else model
     settings = _usage_model_settings(model, None) if isinstance(model, str) else None
+    if timeout is not None:
+        merged = dict(settings) if settings is not None else {}
+        merged["timeout"] = timeout
+        settings = merged
     try:
         return Agent(
             routed,
@@ -238,6 +252,8 @@ def extract_document(
     max_input_bytes: int | None = DEFAULT_MAX_INPUT_BYTES,
     additional_properties_false: bool = True,
     cite: bool = False,
+    timeout: float | None = DEFAULT_CALL_TIMEOUT,
+    window_concurrency: int = DEFAULT_WINDOW_CONCURRENCY,
 ) -> tuple[dict[str, Any], Usage]:
     """Extract one document with openextract using an ExtractBench JSON schema."""
     data, usage, _citations = extract_document_with_citations(
@@ -250,6 +266,8 @@ def extract_document(
         max_input_bytes=max_input_bytes,
         additional_properties_false=additional_properties_false,
         cite=cite,
+        timeout=timeout,
+        window_concurrency=window_concurrency,
     )
     return data, usage
 
@@ -265,6 +283,8 @@ def extract_document_with_citations(
     max_input_bytes: int | None = DEFAULT_MAX_INPUT_BYTES,
     additional_properties_false: bool = True,
     cite: bool = True,
+    timeout: float | None = DEFAULT_CALL_TIMEOUT,
+    window_concurrency: int = DEFAULT_WINDOW_CONCURRENCY,
 ) -> tuple[dict[str, Any], Usage, tuple[Citation, ...]]:
     """Extract one document and return ``(data, usage, citations)``.
 
@@ -272,41 +292,90 @@ def extract_document_with_citations(
     an ``output`` / ``citations`` envelope so the model can return per-field
     page and quote evidence. PDFs are parsed locally first and sent as
     page-indexed windows so large documents do not blow the model context.
-    Boxes come from parser spans, never from the model.
+    Window citations are collected before reduce so a later window's cites
+    are not dropped. Boxes come from parser spans, never from the model.
     """
     schema = prepare_schema(json_schema, additional_properties_false=additional_properties_false)
     run_instructions = with_citation_instructions(instructions) if cite else instructions
     if cite:
         schema = json_schema_with_citations(schema)
     run_source, run_media_type, parsed = _parse_then_extract_source(source, media_type)
-    agent = _build_schema_agent(model, schema, run_instructions)
     policy = RetryPolicy(max_retries=max_retries)
     windows = parse_windows(parsed) if parsed is not None and parsed.has_text() else ()
-    with Extractor(
-        ExtractedDocument,
-        agent=agent,
-        retry_policy=policy,
-        max_input_bytes=max_input_bytes,
-    ) as extractor:
-        if len(windows) > 1:
-            parts: list[ExtractedDocument] = []
-            usages: list[Usage] = []
-            for window in windows:
-                part, part_usage = extractor.extract_with_usage(
-                    window.as_prompt_text().encode("utf-8"),
-                    media_type="text/plain",
-                )
-                parts.append(part)
-                usages.append(part_usage)
-            output = reduce_outputs(parts)
-            usage = _sum_usage(usages)
-        else:
+    if len(windows) > 1:
+        payloads, usage = _extract_parse_windows(
+            windows,
+            model,
+            schema,
+            run_instructions,
+            policy=policy,
+            max_input_bytes=max_input_bytes,
+            timeout=timeout,
+            window_concurrency=window_concurrency,
+        )
+        data, citations = _merge_window_payloads(payloads, cite=cite)
+    else:
+        agent = _build_schema_agent(model, schema, run_instructions, timeout=timeout)
+        with Extractor(
+            ExtractedDocument,
+            agent=agent,
+            retry_policy=policy,
+            max_input_bytes=max_input_bytes,
+        ) as extractor:
             output, usage = extractor.extract_with_usage(run_source, media_type=run_media_type)
-    dumped = as_extracted_dict(output)
-    data, citations = _unwrap_cited_document(dumped, cite=cite)
+        data, citations = _unwrap_cited_document(as_extracted_dict(output), cite=cite)
     if cite:
         citations = ground_citations(citations, parsed, data)
     return data, usage, citations
+
+
+def _extract_parse_windows(
+    windows: tuple,
+    model: str | object,
+    schema: dict[str, Any],
+    instructions: str,
+    *,
+    policy: RetryPolicy,
+    max_input_bytes: int | None,
+    timeout: float | None,
+    window_concurrency: int,
+) -> tuple[list[dict[str, Any]], Usage]:
+    """Extract each parse window and sum usage. Citations are unwrapped later."""
+    sources = [window.as_prompt_text().encode("utf-8") for window in windows]
+    workers = max(1, min(window_concurrency, len(sources)))
+
+    def _run(source: bytes) -> tuple[ExtractedDocument, Usage]:
+        agent = _build_schema_agent(model, schema, instructions, timeout=timeout)
+        with Extractor(
+            ExtractedDocument,
+            agent=agent,
+            retry_policy=policy,
+            max_input_bytes=max_input_bytes,
+        ) as extractor:
+            return extractor.extract_with_usage(source, media_type="text/plain")
+
+    if workers == 1:
+        pairs = [_run(source) for source in sources]
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            pairs = list(pool.map(_run, sources))
+    return [as_extracted_dict(part) for part, _usage in pairs], _sum_usage(
+        usage for _part, usage in pairs
+    )
+
+
+def _merge_window_payloads(
+    payloads: list[dict[str, Any]], *, cite: bool
+) -> tuple[dict[str, Any], tuple[Citation, ...]]:
+    """Reduce window extractions and keep every window's citations."""
+    data_parts: list[ExtractedDocument] = []
+    citations: list[Citation] = []
+    for payload in payloads:
+        data, cites = _unwrap_cited_document(payload, cite=cite)
+        data_parts.append(ExtractedDocument.model_validate(data))
+        citations.extend(cites)
+    merged = as_extracted_dict(reduce_outputs(data_parts)) if data_parts else {}
+    return merged, tuple(citations)
 
 
 def _parse_then_extract_source(
@@ -423,6 +492,8 @@ def register_openextract_pipeline(
     input_price_per_1m: float = 0.0,
     output_price_per_1m: float = 0.0,
     cite: bool = True,
+    timeout: float | None = DEFAULT_CALL_TIMEOUT,
+    window_concurrency: int = DEFAULT_WINDOW_CONCURRENCY,
 ) -> str:
     """Register the openextract ExtractBench provider and pipeline; return its name."""
     from extract_bench.inference.pipelines import get_pipeline, register_pipeline
@@ -455,6 +526,8 @@ def register_openextract_pipeline(
         "input_price_per_1m": input_price_per_1m,
         "output_price_per_1m": output_price_per_1m,
         "cite": cite,
+        "timeout": timeout,
+        "window_concurrency": window_concurrency,
     }
 
     if "openextract" not in _PROVIDER_REGISTRY:
@@ -490,6 +563,10 @@ def register_openextract_pipeline(
                             cfg.get("additional_properties_false", True)
                         ),
                         cite=bool(cfg.get("cite", True)),
+                        timeout=cfg.get("timeout", DEFAULT_CALL_TIMEOUT),
+                        window_concurrency=int(
+                            cfg.get("window_concurrency", DEFAULT_WINDOW_CONCURRENCY)
+                        ),
                     )
                 except ProviderNotInstalledError as exc:
                     raise ProviderConfigError(str(exc)) from exc
@@ -498,6 +575,8 @@ def register_openextract_pipeline(
                         raise ProviderTransientError(str(exc)) from exc
                     raise ProviderPermanentError(str(exc)) from exc
                 except (SchemaValidationError, InputTooLargeError, TypeError) as exc:
+                    raise ProviderPermanentError(str(exc)) from exc
+                except ExtractionError as exc:
                     raise ProviderPermanentError(str(exc)) from exc
 
                 completed_at = datetime.now()
@@ -594,6 +673,18 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--max-concurrent", type=int, default=4, help="parallel documents (default: 4)"
     )
     parser.add_argument("--max-retries", type=int, default=2, help="transient ModelError retries")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=DEFAULT_CALL_TIMEOUT,
+        help=f"per-window model timeout in seconds (default: {int(DEFAULT_CALL_TIMEOUT)})",
+    )
+    parser.add_argument(
+        "--window-concurrency",
+        type=int,
+        default=DEFAULT_WINDOW_CONCURRENCY,
+        help="parallel parse windows per document (default: 4)",
+    )
     parser.add_argument(
         "--max-input-bytes",
         type=int,
@@ -700,6 +791,8 @@ def main(argv: list[str] | None = None) -> int:
         input_price_per_1m=args.input_price_per_1m,
         output_price_per_1m=args.output_price_per_1m,
         cite=args.cite,
+        timeout=args.timeout,
+        window_concurrency=args.window_concurrency,
     )
     print(f"Pipeline: {name}")
     print(f"Model:    {model}")

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -21,7 +21,7 @@ import os
 import re
 import subprocess
 import sys
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
 from pathlib import Path
 from typing import Any
 
@@ -308,7 +308,6 @@ def extract_document_with_citations(
             model,
             schema,
             run_instructions,
-            policy=policy,
             max_input_bytes=max_input_bytes,
             timeout=timeout,
             window_concurrency=window_concurrency,
@@ -335,21 +334,26 @@ def _extract_parse_windows(
     schema: dict[str, Any],
     instructions: str,
     *,
-    policy: RetryPolicy,
     max_input_bytes: int | None,
     timeout: float | None,
     window_concurrency: int,
 ) -> tuple[list[dict[str, Any]], Usage]:
-    """Extract each parse window and sum usage. Citations are unwrapped later."""
+    """Extract each parse window and sum usage. Citations are unwrapped later.
+
+    Each window is a single attempt. File-level ExtractBench retries still apply
+    to transient errors; a hung window must not burn the 1800s per-file budget
+    three times (pueblo / long on the 6-doc smoke).
+    """
     sources = [window.as_prompt_text().encode("utf-8") for window in windows]
     workers = max(1, min(window_concurrency, len(sources)))
+    once = RetryPolicy(max_retries=0)
 
     def _run(source: bytes) -> tuple[ExtractedDocument, Usage]:
         agent = _build_schema_agent(model, schema, instructions, timeout=timeout)
         with Extractor(
             ExtractedDocument,
             agent=agent,
-            retry_policy=policy,
+            retry_policy=once,
             max_input_bytes=max_input_bytes,
         ) as extractor:
             return extractor.extract_with_usage(source, media_type="text/plain")
@@ -358,10 +362,31 @@ def _extract_parse_windows(
         pairs = [_run(source) for source in sources]
     else:
         with ThreadPoolExecutor(max_workers=workers) as pool:
-            pairs = list(pool.map(_run, sources))
+            futures = [pool.submit(_run, source) for source in sources]
+            try:
+                pairs = [
+                    future.result() if timeout is None else future.result(timeout=timeout)
+                    for future in futures
+                ]
+            except FuturesTimeoutError as exc:
+                for future in futures:
+                    future.cancel()
+                raise ModelError(
+                    f"Parse window timed out after {timeout}s",
+                    retryable=False,
+                ) from exc
     return [as_extracted_dict(part) for part, _usage in pairs], _sum_usage(
         usage for _part, usage in pairs
     )
+
+
+def _extractbench_retryable(exc: ModelError) -> bool:
+    """True when ExtractBench should retry the whole file.
+
+    Token-limit and request timeouts are permanent. Retrying them is how
+    pueblo/long spent 1800s three times on the same doomed prompt.
+    """
+    return exc.retryable and "timeout" not in str(exc).lower()
 
 
 def _merge_window_payloads(
@@ -571,7 +596,7 @@ def register_openextract_pipeline(
                 except ProviderNotInstalledError as exc:
                     raise ProviderConfigError(str(exc)) from exc
                 except ModelError as exc:
-                    if exc.retryable:
+                    if _extractbench_retryable(exc):
                         raise ProviderTransientError(str(exc)) from exc
                     raise ProviderPermanentError(str(exc)) from exc
                 except (SchemaValidationError, InputTooLargeError, TypeError) as exc:

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -21,7 +21,8 @@ import os
 import re
 import subprocess
 import sys
-from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
 from pathlib import Path
 from typing import Any
 

--- a/src/openextract/_agent.py
+++ b/src/openextract/_agent.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, cast
 
 from ._config import _validate_timeout
@@ -235,7 +235,8 @@ def _token_count(raw: object, names: tuple[str, ...]) -> int:
 
 def _nested_usage_container(raw: object, key: str) -> object:
     if isinstance(raw, dict):
-        return raw.get(key)
+        mapping = cast(dict[str, object], raw)
+        return mapping.get(key)
     return getattr(raw, key, None)
 
 
@@ -268,8 +269,9 @@ def _usage_from_raw_depth(raw: object, depth: int) -> Usage:
 def _maybe_call(value: object) -> object:
     if not callable(value):
         return value
+    invoke = cast(Callable[[], object], value)
     try:
-        return value()
+        return invoke()
     except TypeError:
         return value
 

--- a/src/openextract/_agent.py
+++ b/src/openextract/_agent.py
@@ -165,6 +165,8 @@ _INPUT_TOKEN_KEYS = (
     "prompt_tokens",
     "inputTokens",
     "promptTokens",
+    "native_tokens_prompt",
+    "native_tokens_input",
 )
 _OUTPUT_TOKEN_KEYS = (
     "output_tokens",
@@ -172,27 +174,52 @@ _OUTPUT_TOKEN_KEYS = (
     "completion_tokens",
     "outputTokens",
     "completionTokens",
+    "native_tokens_completion",
+    "native_tokens_output",
 )
-_TOTAL_TOKEN_KEYS = ("total_tokens", "totalTokens")
+_TOTAL_TOKEN_KEYS = ("total_tokens", "totalTokens", "native_tokens_total")
+_USAGE_NEST_KEYS = ("details", "usage", "provider_details", "extra", "raw", "body")
 
 
 def _usage_model_settings(
     model: str | Model, model_settings: ModelSettings | None
 ) -> ModelSettings | None:
-    """Ask OpenRouter to include native usage so token counts are not zero."""
+    """Ask OpenRouter to include native usage so token counts are not zero.
+
+    ``openrouter_usage`` is the pydantic-ai setting. ``extra_body.usage`` is
+    the raw OpenRouter request field, used when the model wrapper does not
+    translate ``openrouter_usage`` (the live GLM-5.3-flash miss).
+    """
     if not (isinstance(model, str) and model.startswith("openrouter")):
         return model_settings
     merged = dict(model_settings) if model_settings is not None else {}
     merged.setdefault("openrouter_usage", {"include": True})
+    extra = dict(merged["extra_body"]) if isinstance(merged.get("extra_body"), dict) else {}
+    extra.setdefault("usage", {"include": True})
+    merged["extra_body"] = extra
     return cast("ModelSettings", merged)
+
+
+def _positive_int(value: object) -> int:
+    """Return a real positive token count, or ``0``."""
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int) and value > 0:
+        return value
+    if isinstance(value, float) and value.is_integer() and value > 0:
+        return int(value)
+    if isinstance(value, str) and value.isdigit():
+        parsed = int(value)
+        return parsed if parsed > 0 else 0
+    return 0
 
 
 def _token_count(raw: object, names: tuple[str, ...]) -> int:
     """Return the first positive alias, skipping default-zero placeholders.
 
-    pydantic-ai ``RunUsage.input_tokens`` defaults to ``0``. Treating that as
-    a real count hid OpenRouter ``request_tokens`` / ``prompt_tokens`` on the
-    same object (and nested ``details``).
+    pydantic-ai ``RunUsage.input_tokens`` defaults to ``0``, and its deprecated
+    ``request_tokens`` property just aliases that zero. Live OpenRouter counts
+    may sit on ``prompt_tokens``, ``native_tokens_*``, or a nested container.
     """
     if isinstance(raw, dict):
         mapping = cast(dict[str, object], raw)
@@ -200,14 +227,25 @@ def _token_count(raw: object, names: tuple[str, ...]) -> int:
     else:
         values = (getattr(raw, name, None) for name in names)
     for value in values:
-        if isinstance(value, int) and not isinstance(value, bool) and value > 0:
-            return value
+        count = _positive_int(value)
+        if count:
+            return count
     return 0
+
+
+def _nested_usage_container(raw: object, key: str) -> object:
+    if isinstance(raw, dict):
+        return raw.get(key)
+    return getattr(raw, key, None)
 
 
 def _usage_from_raw(raw: object) -> Usage:
     """Read token counts from a provider or pydantic-ai usage object."""
-    if raw is None:
+    return _usage_from_raw_depth(raw, 0)
+
+
+def _usage_from_raw_depth(raw: object, depth: int) -> Usage:
+    if raw is None or depth > 4:
         return Usage(0, 0, 0)
     if isinstance(raw, Usage):
         return raw
@@ -215,18 +253,25 @@ def _usage_from_raw(raw: object) -> Usage:
     output_tokens = _token_count(raw, _OUTPUT_TOKEN_KEYS)
     total_tokens = _token_count(raw, _TOTAL_TOKEN_KEYS)
     if input_tokens == 0 and output_tokens == 0:
-        details = (
-            cast(dict[str, object], raw).get("details")
-            if isinstance(raw, dict)
-            else getattr(raw, "details", None)
-        )
-        if details is not None:
-            input_tokens = _token_count(details, _INPUT_TOKEN_KEYS)
-            output_tokens = _token_count(details, _OUTPUT_TOKEN_KEYS)
-            total_tokens = total_tokens or _token_count(details, _TOTAL_TOKEN_KEYS)
+        for key in _USAGE_NEST_KEYS:
+            nested = _nested_usage_container(raw, key)
+            if nested is None or nested is raw:
+                continue
+            found = _usage_from_raw_depth(nested, depth + 1)
+            if found.input_tokens or found.output_tokens or found.total_tokens:
+                return found
     if total_tokens == 0:
         total_tokens = input_tokens + output_tokens
     return Usage(input_tokens, output_tokens, total_tokens)
+
+
+def _maybe_call(value: object) -> object:
+    if not callable(value):
+        return value
+    try:
+        return value()
+    except TypeError:
+        return value
 
 
 def _extract_usage_object(result: object) -> object:
@@ -238,26 +283,35 @@ def _extract_usage_object(result: object) -> object:
     if usage is not None and descriptor is not None and not callable(descriptor):
         return usage
     if callable(usage):
-        try:
-            return usage()
-        except TypeError:
-            return usage
+        return _maybe_call(usage)
     if usage is not None:
         return usage
     return result
 
 
-def _usage_from_result(result) -> Usage:
-    """Build a ``Usage`` from a pydantic-ai run result or provider usage object."""
-    usage = _usage_from_raw(_extract_usage_object(result))
-    if usage.input_tokens or usage.output_tokens or usage.total_tokens:
-        return usage
+def _usage_candidates(result: object) -> list[object]:
+    """Collect usage-bearing objects from a pydantic-ai run result."""
+    found: list[object] = [_extract_usage_object(result)]
     response = getattr(result, "response", None)
     descriptor = getattr(type(result), "response", None)
-    if response is None or descriptor is None or callable(descriptor):
-        return usage
-    nested = getattr(response, "usage", None)
-    return _usage_from_raw(nested) if nested is not None else usage
+    if response is not None and descriptor is not None and not callable(descriptor):
+        found.append(getattr(response, "usage", None))
+        found.append(getattr(response, "provider_details", None))
+    messages = _maybe_call(getattr(result, "all_messages", None))
+    if isinstance(messages, list):
+        for message in messages:
+            found.append(getattr(message, "usage", None))
+            found.append(getattr(message, "provider_details", None))
+    return found
+
+
+def _usage_from_result(result) -> Usage:
+    """Build a ``Usage`` from a pydantic-ai run result or provider usage object."""
+    for candidate in _usage_candidates(result):
+        usage = _usage_from_raw(candidate)
+        if usage.input_tokens or usage.output_tokens or usage.total_tokens:
+            return usage
+    return Usage(0, 0, 0)
 
 
 def _model_identifier(model: str | Model, agent: object) -> str | None:

--- a/src/openextract/_errors.py
+++ b/src/openextract/_errors.py
@@ -46,6 +46,18 @@ _PERMANENT_ERROR_NAMES = (
     "unprocessable",
     "notfound",
     "accessdenied",
+    "tokenlimit",
+    "contextwindow",
+    "contextlength",
+    "maximumcontext",
+)
+_TOKEN_LIMIT_MARKERS = (
+    "token limit",
+    "context window",
+    "context length",
+    "maximum context",
+    "prompt is too long",
+    "exceeded before any response",
 )
 
 # Exact (module, class) signatures for provider/model error bases we classify
@@ -216,6 +228,12 @@ def _is_transient_model_exception(exc: BaseException, status_code: int | None) -
     return any(name in error_name for name in _TRANSIENT_ERROR_NAMES)
 
 
+def _is_token_limit_error(exc: BaseException) -> bool:
+    """True when the provider or pydantic-ai rejected the prompt as too large."""
+    message = str(exc).lower()
+    return any(marker in message for marker in _TOKEN_LIMIT_MARKERS)
+
+
 def _map_exception(exc: BaseException) -> ExtractionError:
     """Translate a low-level exception into the appropriate ExtractionError subclass."""
     if isinstance(exc, httpx.HTTPStatusError):
@@ -224,6 +242,13 @@ def _map_exception(exc: BaseException) -> ExtractionError:
         return UrlFetchError(f"Failed to fetch URL: {exc}")
     if isinstance(exc, ValidationError):
         return SchemaValidationError(f"Model output did not match schema: {exc}")
+    if _is_token_limit_error(exc):
+        return ModelError(
+            f"Model token limit exceeded: {exc}",
+            provider=_model_provider(exc),
+            status_code=_model_status_code(exc),
+            retryable=False,
+        )
     if _is_model_exception(exc):
         status_code = _model_status_code(exc)
         return ModelError(

--- a/src/openextract/_parse.py
+++ b/src/openextract/_parse.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from collections.abc import Iterator
 from dataclasses import dataclass
 from difflib import SequenceMatcher
@@ -14,8 +15,11 @@ from ._types import Citation
 _PDF_TYPES = frozenset({"application/pdf", "application/x-pdf"})
 _PAGE_HEADER = "--- Page {page} ---"
 _FUZZY_RATIO = 0.85
-# ~20k tokens of document text, leaving room for schema, instructions, and output.
-DEFAULT_PARSE_WINDOW_CHARS = 80_000
+# ~3k tokens of document text. GLM-class context still needs room for a large
+# ExtractBench schema, citation envelope, and output. Oversized pages are split.
+DEFAULT_PARSE_WINDOW_CHARS = 12_000
+# pypdfium2 / PDFium is not safe across threads in one process.
+_PDFIUM_LOCK = threading.Lock()
 
 
 @dataclass(frozen=True)
@@ -93,17 +97,20 @@ def parse_windows(
 ) -> tuple[ParsedDocument, ...]:
     """Split ``parsed`` into page-contiguous windows under ``max_chars``.
 
-    A single page larger than the budget is still its own window so parser
-    boxes keep the full page text. Empty documents yield the original parse.
+    A page larger than the budget is sliced so each model call stays inside
+    GLM-class context. Slices keep the original page number and parser spans;
+    boxes are still resolved against the full parse, never invented. Empty
+    documents yield the original parse.
     """
     budget = DEFAULT_PARSE_WINDOW_CHARS if max_chars is None else max_chars
     pages = parsed.pages
     if not pages or _pages_prompt_len(pages) <= budget:
         return (parsed,)
+    slices = tuple(slice_page for page in pages for slice_page in _split_page(page, budget))
     windows: list[ParsedDocument] = []
     current: list[ParsedPage] = []
     current_len = 0
-    for page in pages:
+    for page in slices:
         block_len = len(_page_block(page))
         extra = block_len if not current else block_len + 2
         if current and current_len + extra > budget:
@@ -115,6 +122,37 @@ def parse_windows(
         current_len += extra
     windows.append(ParsedDocument(pages=tuple(current)))
     return tuple(windows)
+
+
+def _split_page(page: ParsedPage, budget: int) -> tuple[ParsedPage, ...]:
+    """Slice one page so each ``--- Page N ---`` block fits ``budget``."""
+    block_len = len(_page_block(page))
+    if block_len <= budget:
+        return (page,)
+    header_len = len(_PAGE_HEADER.format(page=page.page)) + 1
+    body_budget = max(1, budget - header_len)
+    text = page.text
+    chunks: list[ParsedPage] = []
+    start = 0
+    while start < len(text):
+        end = min(len(text), start + body_budget)
+        if end < len(text):
+            break_at = text.rfind("\n", start, end)
+            if break_at <= start:
+                break_at = text.rfind(" ", start, end)
+            if break_at > start:
+                end = break_at + 1
+        chunks.append(
+            ParsedPage(
+                page=page.page,
+                text=text[start:end],
+                width=page.width,
+                height=page.height,
+                spans=page.spans,
+            )
+        )
+        start = end
+    return tuple(chunks) or (page,)
 
 
 def parsed_window_inputs(
@@ -188,19 +226,20 @@ def _parse_pdf(data: bytes) -> ParsedDocument | None:
         import pypdfium2 as pdfium
     except ImportError:
         return None
-    try:
-        pdf = pdfium.PdfDocument(data)
-    except Exception:
-        return None
-    try:
-        pages = tuple(_parse_pdf_page(pdf, index) for index in range(len(pdf)))
-    except Exception:
-        return None
-    finally:
-        close = getattr(pdf, "close", None)
-        if callable(close):
-            close()
-    return ParsedDocument(pages=pages) if pages else None
+    with _PDFIUM_LOCK:
+        try:
+            pdf = pdfium.PdfDocument(data)
+        except Exception:
+            return None
+        try:
+            pages = tuple(_parse_pdf_page(pdf, index) for index in range(len(pdf)))
+        except Exception:
+            return None
+        finally:
+            close = getattr(pdf, "close", None)
+            if callable(close):
+                close()
+        return ParsedDocument(pages=pages) if pages else None
 
 
 def _parse_pdf_page(pdf: Any, index: int) -> ParsedPage:

--- a/src/openextract/_parse.py
+++ b/src/openextract/_parse.py
@@ -17,7 +17,10 @@ _PAGE_HEADER = "--- Page {page} ---"
 _FUZZY_RATIO = 0.85
 # ~3k tokens of document text. GLM-class context still needs room for a large
 # ExtractBench schema, citation envelope, and output. Oversized pages are split.
+# Slide decks can sit under the char budget and still blow context as one prompt
+# (Veralto was a single 80k window), so also cap pages per window.
 DEFAULT_PARSE_WINDOW_CHARS = 12_000
+DEFAULT_PARSE_WINDOW_PAGES = 4
 # pypdfium2 / PDFium is not safe across threads in one process.
 _PDFIUM_LOCK = threading.Lock()
 
@@ -94,17 +97,20 @@ def parse_windows(
     parsed: ParsedDocument,
     *,
     max_chars: int | None = None,
+    max_pages: int | None = None,
 ) -> tuple[ParsedDocument, ...]:
     """Split ``parsed`` into page-contiguous windows under ``max_chars``.
 
     A page larger than the budget is sliced so each model call stays inside
     GLM-class context. Slices keep the original page number and parser spans;
-    boxes are still resolved against the full parse, never invented. Empty
+    boxes are still resolved against the full parse, never invented. Decks that
+    fit the character budget still split once they exceed ``max_pages``. Empty
     documents yield the original parse.
     """
     budget = DEFAULT_PARSE_WINDOW_CHARS if max_chars is None else max_chars
+    page_cap = DEFAULT_PARSE_WINDOW_PAGES if max_pages is None else max_pages
     pages = parsed.pages
-    if not pages or _pages_prompt_len(pages) <= budget:
+    if not pages or (_pages_prompt_len(pages) <= budget and len(pages) <= page_cap):
         return (parsed,)
     slices = tuple(slice_page for page in pages for slice_page in _split_page(page, budget))
     windows: list[ParsedDocument] = []
@@ -113,7 +119,7 @@ def parse_windows(
     for page in slices:
         block_len = len(_page_block(page))
         extra = block_len if not current else block_len + 2
-        if current and current_len + extra > budget:
+        if current and (current_len + extra > budget or len(current) >= page_cap):
             windows.append(ParsedDocument(pages=tuple(current)))
             current = [page]
             current_len = block_len
@@ -160,6 +166,7 @@ def parsed_window_inputs(
     fallback_inputs: list,
     *,
     max_chars: int | None = None,
+    max_pages: int | None = None,
 ) -> list[list]:
     """Return per-window run inputs, or ``[fallback_inputs]`` for the fast path.
 
@@ -168,7 +175,7 @@ def parsed_window_inputs(
     """
     if parsed is None or not parsed.has_text():
         return [fallback_inputs]
-    windows = parse_windows(parsed, max_chars=max_chars)
+    windows = parse_windows(parsed, max_chars=max_chars, max_pages=max_pages)
     if len(windows) == 1:
         return [fallback_inputs]
     return [parsed_run_inputs(window) for window in windows]

--- a/src/openextract/_parse.py
+++ b/src/openextract/_parse.py
@@ -18,9 +18,10 @@ _FUZZY_RATIO = 0.85
 # ~3k tokens of document text. GLM-class context still needs room for a large
 # ExtractBench schema, citation envelope, and output. Oversized pages are split.
 # Slide decks can sit under the char budget and still blow context as one prompt
-# (Veralto was a single 80k window), so also cap pages per window.
+# (Veralto was a single 80k window). One page per window forces those decks to
+# split; an oversized page is still sliced by the char budget.
 DEFAULT_PARSE_WINDOW_CHARS = 12_000
-DEFAULT_PARSE_WINDOW_PAGES = 4
+DEFAULT_PARSE_WINDOW_PAGES = 1
 # pypdfium2 / PDFium is not safe across threads in one process.
 _PDFIUM_LOCK = threading.Lock()
 
@@ -104,7 +105,8 @@ def parse_windows(
     A page larger than the budget is sliced so each model call stays inside
     GLM-class context. Slices keep the original page number and parser spans;
     boxes are still resolved against the full parse, never invented. Decks that
-    fit the character budget still split once they exceed ``max_pages``. Empty
+    fit the character budget still split once they exceed ``max_pages``
+    (default one page, so a Veralto-class deck cannot stay one prompt). Empty
     documents yield the original parse.
     """
     budget = DEFAULT_PARSE_WINDOW_CHARS if max_chars is None else max_chars

--- a/src/openextract/_parse.py
+++ b/src/openextract/_parse.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import threading
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -499,10 +500,39 @@ def _union_coco(
 
 
 def _citation_from_value(field: str, value: str, parsed: ParsedDocument) -> Citation | None:
-    page, bbox = find_span(parsed, value)
-    if page is None:
-        return None
-    return Citation(field=field, quote=value, page=page, bbox=bbox)
+    """Locate ``value`` in the parse, including numeric display variants.
+
+    Window extract often returns schema numbers (``1234.0``) with an empty
+    citation list. ExtractBench still needs a page, so try thousands-separated
+    and whole-integer forms that appear in the PDF.
+    """
+    for needle in _value_needles(value):
+        page, bbox = find_span(parsed, needle)
+        if page is not None:
+            return Citation(field=field, quote=needle, page=page, bbox=bbox)
+    return None
+
+
+def _value_needles(value: str) -> tuple[str, ...]:
+    """Search texts for a field value, including ``1,234`` / ``1234.0`` forms."""
+    texts = [value]
+    stripped = value.replace(",", "").replace("$", "").replace("£", "").replace("€", "").strip()
+    if stripped and stripped != value:
+        texts.append(stripped)
+    try:
+        number = float(stripped)
+    except ValueError:
+        return tuple(dict.fromkeys(texts))
+    if not math.isfinite(number) or abs(number) >= 1e15:
+        return tuple(dict.fromkeys(texts))
+    if number.is_integer():
+        integer = int(number)
+        texts.append(str(integer))
+        texts.append(f"{integer:,}")
+    else:
+        texts.append(f"{number:.2f}")
+        texts.append(f"{number:,.2f}")
+    return tuple(dict.fromkeys(text for text in texts if text))
 
 
 def _iter_field_values(output: object) -> Iterator[tuple[str, str]]:

--- a/src/openextract/_windows.py
+++ b/src/openextract/_windows.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Sequence
 
 from ._citations import split_cited_output
-from ._parse import ParsedDocument, parsed_window_inputs
+from ._parse import ParsedDocument, ground_citations, parsed_window_inputs
 from ._reduce import reduce_outputs
 from ._retry import _run_with_retries_async, _run_with_retries_sync
 from ._types import Citation, T, Usage, _sum_usage
@@ -48,7 +48,7 @@ def extract_windows_sync(
         outputs.append(output)
         usages.append(usage)
         citations.extend(cites)
-    return _fold_windows(outputs, usages, citations)
+    return _finish_windows(outputs, usages, citations, parsed, cite)
 
 
 async def extract_windows_async(
@@ -85,7 +85,21 @@ async def extract_windows_async(
         outputs.append(output)
         usages.append(usage)
         citations.extend(cites)
-    return _fold_windows(outputs, usages, citations)
+    return _finish_windows(outputs, usages, citations, parsed, cite)
+
+
+def _finish_windows(
+    outputs: Sequence[T],
+    usages: Sequence[Usage],
+    citations: list[Citation],
+    parsed: ParsedDocument | None,
+    cite: bool,
+) -> tuple[T, Usage, tuple[Citation, ...]]:
+    """Reduce window values, then backfill cites the model omitted."""
+    output, usage, merged = _fold_windows(outputs, usages, citations)
+    if cite:
+        return output, usage, ground_citations(merged, parsed, output)
+    return output, usage, merged
 
 
 def _fold_windows(

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1304,6 +1304,15 @@ class TestExtract:
         assert mapped.provider is None
         assert mapped.retryable is False
 
+    def test_token_limit_is_permanent_even_without_model_signature(self):
+        mapped = _map_exception(
+            RuntimeError(
+                "Model token limit (provider default) exceeded before any response was generated."
+            )
+        )
+        assert isinstance(mapped, ModelError)
+        assert mapped.retryable is False
+
     def test_model_error_constructor_remains_backwards_compatible(self):
         error = ModelError("flaky")
 
@@ -1748,7 +1757,54 @@ class TestExtractWithUsage:
         assert _usage_model_settings("openai:gpt-5", None) is None
         settings = _usage_model_settings("openrouter:anthropic/claude-sonnet-4", {"temperature": 0})
         assert settings["openrouter_usage"] == {"include": True}
+        assert settings["extra_body"]["usage"] == {"include": True}
         assert settings["temperature"] == 0
+        merged = _usage_model_settings(
+            "openrouter:z-ai/glm-5.3-flash", {"extra_body": {"provider": {"sort": "price"}}}
+        )
+        assert merged["extra_body"]["usage"] == {"include": True}
+        assert merged["extra_body"]["provider"] == {"sort": "price"}
+        replaced = _usage_model_settings("openrouter:x", {"extra_body": "nope"})
+        assert replaced["extra_body"]["usage"] == {"include": True}
+
+        class _ZeroRunUsage:
+            input_tokens = 0
+            output_tokens = 0
+
+            @property
+            def request_tokens(self):
+                return self.input_tokens
+
+            @property
+            def total_tokens(self):
+                return 0
+
+            details = {}
+
+        class _LiveOpenRouterResult:
+            @property
+            def usage(self):
+                return _ZeroRunUsage()
+
+            def all_messages(self):
+                return [
+                    SimpleNamespace(
+                        usage=None,
+                        provider_details={
+                            "native_tokens_prompt": 640,
+                            "native_tokens_completion": 16,
+                        },
+                    )
+                ]
+
+        assert _usage_from_result(_LiveOpenRouterResult()) == Usage(640, 16, 656)
+        nested_usage = {"usage": {"prompt_tokens": "99", "completion_tokens": 2.0}}
+        assert _usage_from_raw(nested_usage) == Usage(99, 2, 101)
+        assert _usage_from_raw({"prompt_tokens": True}) == Usage(0, 0, 0)
+        assert _usage_from_raw({"completion_tokens": "nope"}) == Usage(0, 0, 0)
+        too_deep = {"details": {"details": {"details": {"details": {"details": {}}}}}}
+        too_deep["details"]["details"]["details"]["details"]["details"]["prompt_tokens"] = 5
+        assert _usage_from_raw(too_deep) == Usage(0, 0, 0)
 
     def test_propagates_runtime_error_as_extraction_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"

--- a/tests/test_extractbench.py
+++ b/tests/test_extractbench.py
@@ -233,6 +233,23 @@ def test_extract_document_chunks_large_parse_and_keeps_boxes(monkeypatch, tmp_pa
     assert all(size < 500 for size in calls)
     assert citations[0].page == 2
     assert citations[0].bbox is not None
+    sequential, sequential_usage, sequential_cites = extractbench.extract_document_with_citations(
+        path,
+        schema,
+        TestModel(
+            custom_output_args={
+                "output": {"vendor": "Acme Corp"},
+                "citations": [{"field": "vendor", "quote": "Acme Corp", "page": 2}],
+            }
+        ),
+        max_retries=0,
+        cite=True,
+        window_concurrency=1,
+        timeout=None,
+    )
+    assert sequential == data
+    assert sequential_usage.input_tokens >= 0
+    assert sequential_cites[0].page == 2
 
 
 def test_unwrap_cited_document_flat_fallback():
@@ -244,10 +261,34 @@ def test_unwrap_cited_document_flat_fallback():
     assert citations[0].page == 1
 
 
+def test_merge_window_payloads_keeps_later_citations():
+    data, citations = extractbench._merge_window_payloads(
+        [
+            {"output": {"vendor": None}, "citations": []},
+            {
+                "output": {"vendor": "Acme Corp"},
+                "citations": [{"field": "vendor", "quote": "Acme Corp", "page": 2}],
+            },
+        ],
+        cite=True,
+    )
+    assert data["vendor"] == "Acme Corp"
+    assert citations[0].page == 2
+    assert citations[0].quote == "Acme Corp"
+    empty, empty_cites = extractbench._merge_window_payloads([], cite=True)
+    assert empty == {}
+    assert empty_cites == ()
+
+
 def test_parse_args_cite_defaults_on():
     args = extractbench.parse_args(["--model", "openai:gpt-5", "--test"])
     assert args.cite is True
     assert extractbench.parse_args(["--model", "openai:gpt-5", "--no-cite"]).cite is False
+    timed = extractbench.parse_args(
+        ["--model", "openai:gpt-5", "--timeout", "90", "--window-concurrency", "2"]
+    )
+    assert timed.timeout == 90
+    assert timed.window_concurrency == 2
 
 
 def test_extract_document_with_test_model():

--- a/tests/test_extractbench.py
+++ b/tests/test_extractbench.py
@@ -300,7 +300,7 @@ def test_window_reduce_backfills_field_citations_when_model_omits_them(tmp_path)
         "properties": {"vendor": {"type": "string"}, "total": {"type": "number"}},
         "required": ["vendor", "total"],
     }
-    pdf = synthetic_pdf(pages=["Vendor Acme Corp", "Total 1,234"])
+    pdf = synthetic_pdf(pages=["Acme Corp", "Total 1,234"])
     path = tmp_path / "bianco.pdf"
     path.write_bytes(pdf)
     data, _usage, citations = extractbench.extract_document_with_citations(

--- a/tests/test_extractbench.py
+++ b/tests/test_extractbench.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 from pydantic_ai.models.test import TestModel
 
-from openextract import Citation, SchemaValidationError
+from openextract import Citation, ModelError, SchemaValidationError
 
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 if str(SCRIPTS) not in sys.path:
@@ -259,6 +259,106 @@ def test_unwrap_cited_document_flat_fallback():
     )
     assert data == {"vendor": "Acme"}
     assert citations[0].page == 1
+
+
+def test_default_windows_split_short_slide_deck(monkeypatch, tmp_path):
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"title": {"type": "string"}},
+        "required": ["title"],
+    }
+    pdf = synthetic_pdf(pages=[f"Slide {index}" for index in range(1, 21)])
+    path = tmp_path / "deck.pdf"
+    path.write_bytes(pdf)
+    calls: list[int] = []
+    original = extractbench.Extractor.extract_with_usage
+
+    def _spy(self, source, *, media_type=None):
+        payload = source if isinstance(source, bytes) else Path(source).read_bytes()
+        calls.append(len(payload))
+        return original(self, source, media_type=media_type)
+
+    monkeypatch.setattr(extractbench.Extractor, "extract_with_usage", _spy)
+    data, _usage, _citations = extractbench.extract_document_with_citations(
+        path,
+        schema,
+        TestModel(custom_output_args={"output": {"title": "Slide 1"}, "citations": []}),
+        max_retries=0,
+        cite=True,
+    )
+    assert data["title"] == "Slide 1"
+    assert len(calls) == 20
+
+
+def test_window_reduce_backfills_field_citations_when_model_omits_them(tmp_path):
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}, "total": {"type": "number"}},
+        "required": ["vendor", "total"],
+    }
+    pdf = synthetic_pdf(pages=["Vendor Acme Corp", "Total 1,234"])
+    path = tmp_path / "bianco.pdf"
+    path.write_bytes(pdf)
+    data, _usage, citations = extractbench.extract_document_with_citations(
+        path,
+        schema,
+        TestModel(
+            custom_output_args={
+                "output": {"vendor": "Acme Corp", "total": 1234},
+                "citations": [],
+            }
+        ),
+        max_retries=0,
+        cite=True,
+    )
+    assert data == {"vendor": "Acme Corp", "total": 1234}
+    mapped = extractbench.field_citations_for_extractbench(citations)
+    paths = {item["field_path"] for item in mapped}
+    assert "vendor" in paths
+    assert any(item["page"] >= 1 for item in mapped)
+
+
+def test_extractbench_does_not_retry_timeouts():
+    assert extractbench._extractbench_retryable(ModelError("rate limited", retryable=True))
+    assert not extractbench._extractbench_retryable(ModelError("request timeout", retryable=True))
+    assert not extractbench._extractbench_retryable(ModelError("token limit", retryable=False))
+
+
+def test_window_pool_timeout_is_permanent(monkeypatch, tmp_path):
+    import time
+
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    pdf = synthetic_pdf(pages=["AAAA page one", "BBBB page two"])
+    path = tmp_path / "slow.pdf"
+    path.write_bytes(pdf)
+    original = extractbench.Extractor.extract_with_usage
+
+    def _slow(self, source, *, media_type=None):
+        time.sleep(0.4)
+        return original(self, source, media_type=media_type)
+
+    monkeypatch.setattr(extractbench.Extractor, "extract_with_usage", _slow)
+    with pytest.raises(ModelError, match="timed out") as exc:
+        extractbench.extract_document_with_citations(
+            path,
+            schema,
+            TestModel(custom_output_args={"output": {"vendor": "Acme"}, "citations": []}),
+            max_retries=0,
+            cite=True,
+            timeout=0.05,
+            window_concurrency=2,
+        )
+    assert exc.value.retryable is False
 
 
 def test_merge_window_payloads_keeps_later_citations():

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -379,11 +379,18 @@ def test_pdf_close_optional(monkeypatch):
 def test_parse_windows_splits_and_caps_large_multipage():
     pages = tuple(_page("x" * 50, page=index) for index in (1, 2, 3, 4))
     parsed = ParsedDocument(pages=pages)
-    assert parse_windows(parsed, max_chars=10_000) == (parsed,)
+    assert parse_windows(parsed, max_chars=10_000, max_pages=10) == (parsed,)
     deck = ParsedDocument(pages=tuple(_page("slide", page=index) for index in range(1, 6)))
     deck_windows = parse_windows(deck, max_chars=10_000)
-    assert len(deck_windows) == 2
+    assert len(deck_windows) == 5
     assert [page.page for window in deck_windows for page in window.pages] == [1, 2, 3, 4, 5]
+    veralto = ParsedDocument(
+        pages=tuple(_page(f"Q4 slide {index} " * 20, page=index) for index in range(1, 21))
+    )
+    assert _pages_prompt_len(veralto.pages) < 80_000
+    veralto_windows = parse_windows(veralto)
+    assert len(veralto_windows) == 20
+    assert all(len(window.pages) == 1 for window in veralto_windows)
     empty = ParsedDocument(pages=())
     assert parse_windows(empty) == (empty,)
     assert _pages_prompt_len(()) == 0
@@ -406,7 +413,7 @@ def test_parse_windows_splits_and_caps_large_multipage():
     fallback = ["keep-me"]
     assert parsed_window_inputs(None, fallback) == [fallback]
     assert parsed_window_inputs(None, fallback)[0] is fallback
-    assert parsed_window_inputs(parsed, fallback, max_chars=10_000)[0] is fallback
+    assert parsed_window_inputs(parsed, fallback, max_chars=10_000, max_pages=10)[0] is fallback
     chunked = parsed_window_inputs(parsed, fallback, max_chars=80)
     assert len(chunked) >= 2
     assert all(len(window[1]) <= 80 or "--- Page " in window[1] for window in chunked)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -26,6 +27,7 @@ from openextract._parse import (
     _pages_prompt_len,
     _parse_pdf_page,
     _pdf_box_to_coco,
+    _split_page,
     _union_coco,
     _union_pdf_boxes,
     _walk_fields,
@@ -383,12 +385,15 @@ def test_parse_windows_splits_and_caps_large_multipage():
     assert _pages_prompt_len(()) == 0
     windows = parse_windows(parsed, max_chars=80)
     assert len(windows) >= 2
-    assert all(
-        _pages_prompt_len(window.pages) <= 80 or len(window.pages) == 1 for window in windows
-    )
+    assert all(_pages_prompt_len(window.pages) <= 80 for window in windows)
     assert [page.page for window in windows for page in window.pages] == [1, 2, 3, 4]
     oversized = ParsedDocument(pages=(_page("y" * 200, page=1),))
-    assert parse_windows(oversized, max_chars=10) == (oversized,)
+    sliced = parse_windows(oversized, max_chars=10)
+    assert len(sliced) >= 2
+    assert all(_pages_prompt_len(window.pages) <= 10 or len(window.pages) == 1 for window in sliced)
+    assert all(page.page == 1 for window in sliced for page in window.pages)
+    empty = _page("", page=1)
+    assert _split_page(empty, 1) == (empty,)
     fallback = ["keep-me"]
     assert parsed_window_inputs(None, fallback) == [fallback]
     assert parsed_window_inputs(None, fallback)[0] is fallback
@@ -418,6 +423,45 @@ def test_chunk_span_still_gets_parser_box():
     assert bbox is not None
     grounded = ground_citations((Citation("vendor", "Acme Corp", page=2),), parsed)
     assert grounded[0].bbox is not None
+
+
+def test_oversized_page_split_keeps_parser_box():
+    parsed = ParsedDocument(
+        pages=(
+            _page(
+                "noise " * 40 + "Acme Corp " + "tail " * 40,
+                ParsedSpan("Acme", 1, (0.1, 0.2, 0.2, 0.05)),
+                ParsedSpan("Corp", 1, (0.3, 0.2, 0.2, 0.05)),
+                page=1,
+            ),
+        )
+    )
+    windows = parse_windows(parsed, max_chars=40)
+    assert len(windows) >= 2
+    assert any("Acme Corp" in window.as_prompt_text() for window in windows)
+    page, bbox = find_span(parsed, "Acme Corp")
+    assert page == 1
+    assert bbox is not None
+
+
+def test_concurrent_pdf_parse_does_not_crash():
+    data = synthetic_pdf("Hello concurrent parse")
+    errors: list[BaseException] = []
+    results: list[ParsedDocument | None] = []
+
+    def _worker() -> None:
+        try:
+            results.append(try_parse_document(data, "application/pdf"))
+        except BaseException as exc:  # noqa: BLE001 - crash is the failure mode
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+    assert errors == []
+    assert all(parsed is not None and parsed.has_text() for parsed in results)
 
 
 def test_extract_chunks_large_parse_via_extract_once(monkeypatch, mocker):

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -380,6 +380,10 @@ def test_parse_windows_splits_and_caps_large_multipage():
     pages = tuple(_page("x" * 50, page=index) for index in (1, 2, 3, 4))
     parsed = ParsedDocument(pages=pages)
     assert parse_windows(parsed, max_chars=10_000) == (parsed,)
+    deck = ParsedDocument(pages=tuple(_page("slide", page=index) for index in range(1, 6)))
+    deck_windows = parse_windows(deck, max_chars=10_000)
+    assert len(deck_windows) == 2
+    assert [page.page for window in deck_windows for page in window.pages] == [1, 2, 3, 4, 5]
     empty = ParsedDocument(pages=())
     assert parse_windows(empty) == (empty,)
     assert _pages_prompt_len(()) == 0

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -30,6 +30,7 @@ from openextract._parse import (
     _split_page,
     _union_coco,
     _union_pdf_boxes,
+    _value_needles,
     _walk_fields,
     _word_spans,
     find_span,
@@ -288,6 +289,25 @@ def test_walk_nested_fields_and_short_quote():
     already = ground_citations((Citation("total", "12.50", 1),), parsed, {"total": "12.50"})
     assert len(already) == 1
     assert _citation_from_value("missing", "zzz", parsed) is None
+    money = ParsedDocument(
+        pages=(
+            _page(
+                "Paid 1,234.00",
+                ParsedSpan("1,234.00", 1, (0.2, 0.1, 0.3, 0.05)),
+            ),
+        )
+    )
+    from_int = ground_citations((), money, {"amount": 1234})
+    from_float = ground_citations((), money, {"amount": 1234.0})
+    assert from_int[0].page == 1 and from_int[0].quote == "1,234"
+    assert from_float[0].page == 1
+    assert "1,234" in _value_needles("1234.0")
+    assert _value_needles("Acme") == ("Acme",)
+    assert _value_needles("inf") == ("inf",)
+    assert _value_needles("nan") == ("nan",)
+    assert "$12" in _value_needles("$12") and "12" in _value_needles("$12")
+    assert _value_needles("1000000000000000") == ("1000000000000000",)
+    assert "12.50" in _value_needles("12.5")
     none_page = _ground_one(Citation("x", "zzz"), parsed)
     assert none_page.page is None and none_page.bbox is None
     assert _find_in_text("abc", "   ") is None
@@ -501,6 +521,13 @@ def test_extract_chunks_large_parse_via_extract_once(monkeypatch, mocker):
     )
     result = extract(_Vendor, model, pdf, media_type="application/pdf", cite=True)
     assert result.vendor == "Acme Corp"
+    plain = extract(
+        _Vendor,
+        TestModel(custom_output_args={"vendor": "Acme Corp"}),
+        pdf,
+        media_type="application/pdf",
+    )
+    assert plain.vendor == "Acme Corp"
     assert spy.call_count >= 2
     for call in spy.call_args_list:
         prompt = call.args[1][1]

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -394,6 +394,11 @@ def test_parse_windows_splits_and_caps_large_multipage():
     assert all(page.page == 1 for window in sliced for page in window.pages)
     empty = _page("", page=1)
     assert _split_page(empty, 1) == (empty,)
+    lined = _page("aaaa\nbbbb\ncccc\ndddd\neeee", page=3)
+    lined_slices = _split_page(lined, 20)
+    assert len(lined_slices) >= 2
+    assert all(slice_page.page == 3 for slice_page in lined_slices)
+    assert "".join(slice_page.text for slice_page in lined_slices) == lined.text
     fallback = ["keep-me"]
     assert parsed_window_inputs(None, fallback) == [fallback]
     assert parsed_window_inputs(None, fallback)[0] is fallback

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -521,13 +521,6 @@ def test_extract_chunks_large_parse_via_extract_once(monkeypatch, mocker):
     )
     result = extract(_Vendor, model, pdf, media_type="application/pdf", cite=True)
     assert result.vendor == "Acme Corp"
-    plain = extract(
-        _Vendor,
-        TestModel(custom_output_args={"vendor": "Acme Corp"}),
-        pdf,
-        media_type="application/pdf",
-    )
-    assert plain.vendor == "Acme Corp"
     assert spy.call_count >= 2
     for call in spy.call_args_list:
         prompt = call.args[1][1]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After #208, a local 6-doc ExtractBench smoke on GLM-5.3-flash still failed Cole's gate: concurrent pypdfium2 parse crashed, Veralto still token-limited (as **one** unsplit window in ~22s), pueblo/long burned 3× 1800s **TimeoutError** (not token-limit), Bianco came back with value 0.93 and **zero** `field_citations`, and OpenRouter usage stayed `0` / `$0`.

This PR makes the windowed parse-then-extract path actually usable on that smoke. Boxes stay parser-backed. No API keys, no version bump, no merge.

## Changes

- **Thread-safe PDF parse:** process-wide lock around `_parse_pdf`. pypdfium2 is not safe under ExtractBench `--max-concurrent 4`.
- **Windows that actually split:** 12k-character budget (was 80k), **one page per window**, and slice a single oversized page. A Veralto-class deck that fit 80k as one prompt now cannot stay one window (20 short slides under 80k → 20 extract calls). Parser spans stay on the original page; boxes are never invented.
- **Citations survive reduce:** ExtractBench unwraps each window and collects cites before `reduce_outputs`. When every window returns `citations: []` (Bianco), pages are backfilled from the reduced values against the full parse, including `1,234` / `1234.0` display forms, so `field_citations` is not empty after mapping.
- **Finish without 1800s×3:** bounded parallel window extract (`--window-concurrency`, default 4), per-call `--timeout` (default 240s, hard `Future.result` cap). Window attempts are not retried. Request timeouts and token-limit errors are **permanent** so ExtractBench does not re-run pueblo/long for 1800s three times.
- **OpenRouter usage:** request native usage via both `openrouter_usage` and `extra_body.usage`. Read `prompt_tokens` / `native_tokens_*` from `result.usage`, nested `details`, `response`, and `all_messages`. Default-zero pydantic-ai `input_tokens` is still skipped. Counts are never invented.

## Testing

- Concurrent synthetic PDF parse under 8 threads does not crash.
- A 20-slide deck whose prompt is under 80k chars splits into 20 one-page ExtractBench calls (the Veralto #208 failure mode).
- Oversized page is split (including newline breaks); parser box still attaches from the full parse.
- Window merge keeps citations from a later window when the first window returns none.
- Two-page extract with empty model cites still emits `field_citations` after reduce (Bianco path).
- `1234` / `1234.0` backfill matches PDF `1,234`.
- Hung window (`Future` timeout) and string `timeout` ModelErrors are non-retryable.
- Live-shaped OpenRouter result (`RunUsage` zeros + `native_tokens_*` on `all_messages`) yields `640 / 16 / 656`.
- Token-limit `RuntimeError` maps to non-retryable `ModelError`.
- `uv run ruff check .`, `uv run ty check`, `scripts/check_api_reference.py`, and `uv run pytest --cov=openextract --cov-fail-under=100` — **771 passed, 5 skipped, 100% coverage**.

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (CHANGELOG Unreleased, extractbench.md)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13fc69cb-53c3-42fc-8990-c4d0c7b3e395?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13fc69cb-53c3-42fc-8990-c4d0c7b3e395&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

