### PR TITLE
Fix ExtractBench 6-doc timeouts, scanned PDF uploads, and zero usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,14 @@ timing when that is known.
 ## [Unreleased]
 
 ### Changed
-- ExtractBench per-file timeout is ``max(1800, timeout × ceil(windows /
-  concurrency))`` for a long-doc window count, and timeout retries are
+- ExtractBench per-file timeout is ``max(1800, window-pool wait)`` for a
+  long-doc window count, and timeout retries are
   disabled. Veralto (41) and long (66) are not killed at 1800s × 3.
-- ExtractBench window-pool wait is ``timeout × ceil(windows / concurrency)``,
-  not one 240s wrap around the whole document. Goshen (10) and pueblo (11)
-  can finish; Veralto (41) and long (66) fail only for a real model error.
+- ExtractBench window-pool wait is
+  ``timeout × (ceil(windows / concurrency) + 1)``, not a sharp
+  ``timeout × batches`` wrap. Pueblo's ~706s 11-window run is not killed at
+  720s; a pool timeout returns immediately instead of waiting on cancelled
+  workers until the 96-window file cap (long / no result.json).
   Window attempts are still not retried.
 - Empty-text / scanned PDFs (Bianco) are rendered to compact grayscale page
   images (long edge ≤ 768px) locally and never uploaded for OpenRouter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,18 +9,22 @@ timing when that is known.
 ## [Unreleased]
 
 ### Changed
+- ExtractBench window-pool wait is ``timeout × ceil(windows / concurrency)``,
+  not one 240s wrap around the whole document. Goshen (10) and pueblo (11)
+  can finish; Veralto (41) and long (66) fail only for a real model error.
+  Window attempts are still not retried.
+- Empty-text / scanned PDFs (Bianco) are rendered to page images locally and
+  never uploaded for OpenRouter document-parse (400 rate-limit). Boxes stay
+  parser-backed; none are invented when the scan has no word spans.
+- OpenRouter usage falls back to provider ``prompt_tokens`` /
+  ``completion_tokens`` when pydantic-ai ``RequestUsage.extract`` leaves
+  zeros (live GLM-5.3-flash / W14). Counts are never invented.
 - Parse-then-extract windows page-indexed PDF text under a 12k-character
   budget (was 80k) and one page per window, and splits a single oversized page so
   each model call fits GLM-class context. Slide decks that fit 80k as one
-  prompt (Veralto) now split. ExtractBench extracts windows in a bounded thread pool
-  (`--window-concurrency`, default 4) with a per-call timeout (`--timeout`,
-  default 240s). Window attempts are not retried; request timeouts and
-  token-limit errors are permanent so ExtractBench does not burn its 1800s
-  per-file limit three times (pueblo / long). Citations are collected from
-  every window before reduce, then missing pages are backfilled from parse
-  values (including ``1,234`` / ``1234.0`` forms) so Bianco-class docs still
-  emit `field_citations` when the model returns an empty cite list. Bounding
-  boxes remain parser-backed only.
+  prompt (Veralto) now split. Citations are collected from every window before
+  reduce, then missing pages are backfilled from parse values (including
+  ``1,234`` / ``1234.0`` forms). Bounding boxes remain parser-backed only.
 - PDF parse takes a process-wide lock. pypdfium2 is not thread-safe; concurrent
   ExtractBench workers no longer crash native PDFium.
 - Usage capture asks OpenRouter for native usage via both `openrouter_usage`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ timing when that is known.
 ## [Unreleased]
 
 ### Changed
+- ExtractBench per-file timeout is ``max(1800, timeout × ceil(windows /
+  concurrency))`` for a long-doc window count, and timeout retries are
+  disabled. Veralto (41) and long (66) are not killed at 1800s × 3.
 - ExtractBench window-pool wait is ``timeout × ceil(windows / concurrency)``,
   not one 240s wrap around the whole document. Goshen (10) and pueblo (11)
   can finish; Veralto (41) and long (66) fail only for a real model error.
   Window attempts are still not retried.
-- Empty-text / scanned PDFs (Bianco) are rendered to page images locally and
-  never uploaded for OpenRouter document-parse (400 rate-limit). Boxes stay
-  parser-backed; none are invented when the scan has no word spans.
+- Empty-text / scanned PDFs (Bianco) are rendered to compact grayscale page
+  images (long edge ≤ 768px) locally and never uploaded for OpenRouter
+  document-parse (400 rate-limit). Boxes stay parser-backed; none are
+  invented when the scan has no word spans.
 - OpenRouter usage falls back to provider ``prompt_tokens`` /
   ``completion_tokens`` when pydantic-ai ``RequestUsage.extract`` leaves
   zeros (live GLM-5.3-flash / W14). Counts are never invented.

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -89,11 +89,14 @@ and feeds page-indexed text (`--- Page N ---`) to the model before extraction.
 Long documents (and oversized pages) are split into windows under a 12k-character
 / 1-page budget, extracted with bounded concurrency (`--window-concurrency`, default 4),
 and merged — the whole PDF is not dumped as one prompt. `--timeout` (default 240s)
-is per window; the document wall budget is `timeout × ceil(windows / concurrency)`
-so a 10-page file is not killed at a single 240s wrap. ExtractBench's per-file
-timeout is raised to at least that budget for a long document (never a hard
-1800s below the pool wait) and per-file timeout retries are off, so Veralto /
-long are not run 3×1800s. Window calls are a single
+is per window; the document wall budget is
+`timeout × (ceil(windows / concurrency) + 1)` so GLM variance of tens of
+seconds (pueblo ~706s vs a sharp 720s) does not kill a finishing extract.
+ExtractBench's per-file timeout is raised to at least that budget for a long
+document (never a hard 1800s below the pool wait) and per-file timeout retries
+are off, so Veralto / long are not run 3×1800s. A pool timeout does not wait
+for cancelled workers (that hang is how long reached the 96-window file cap
+with no result.json). Window calls are a single
 attempt; request timeouts and token-limit errors are not retried at file
 level. Scanned / empty-text PDFs are rendered to compact grayscale page images
 (long edge ≤ 768px) locally and are

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -88,11 +88,13 @@ The runner **parses PDFs locally** (pypdfium2, `openextract[pdf]` / `openextract
 and feeds page-indexed text (`--- Page N ---`) to the model before extraction.
 Long documents (and oversized pages) are split into windows under a 12k-character
 / 1-page budget, extracted with bounded concurrency (`--window-concurrency`, default 4),
-and merged — the whole PDF is not dumped as one prompt. Each model call uses
-`--timeout` (default 240s) so a doomed window fails fast instead of burning
-ExtractBench's 1800s per-file limit three times. Window calls are a single
+and merged — the whole PDF is not dumped as one prompt. `--timeout` (default 240s)
+is per window; the document wall budget is `timeout × ceil(windows / concurrency)`
+so a 10-page file is not killed at a single 240s wrap. Window calls are a single
 attempt; request timeouts and token-limit errors are not retried at file
-level. Citations are collected from every window before reduce. When a window
+level. Scanned / empty-text PDFs are rendered to page images locally and are
+never uploaded for provider document-parse. Citations are collected from
+every window before reduce. When a window
 returns values but no cites, pages are backfilled from the local parse
 (including numeric display variants). Boxes are never invented and are never
 taken from the model: if a parser span matches the quote (exact, then simple

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -90,9 +90,13 @@ Long documents (and oversized pages) are split into windows under a 12k-characte
 / 1-page budget, extracted with bounded concurrency (`--window-concurrency`, default 4),
 and merged — the whole PDF is not dumped as one prompt. `--timeout` (default 240s)
 is per window; the document wall budget is `timeout × ceil(windows / concurrency)`
-so a 10-page file is not killed at a single 240s wrap. Window calls are a single
+so a 10-page file is not killed at a single 240s wrap. ExtractBench's per-file
+timeout is raised to at least that budget for a long document (never a hard
+1800s below the pool wait) and per-file timeout retries are off, so Veralto /
+long are not run 3×1800s. Window calls are a single
 attempt; request timeouts and token-limit errors are not retried at file
-level. Scanned / empty-text PDFs are rendered to page images locally and are
+level. Scanned / empty-text PDFs are rendered to compact grayscale page images
+(long edge ≤ 768px) locally and are
 never uploaded for provider document-parse. Citations are collected from
 every window before reduce. When a window
 returns values but no cites, pages are backfilled from the local parse

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -78,6 +78,9 @@ DEFAULT_WINDOW_CONCURRENCY = 4
 # cap must be ≥ pool budget. 96 windows covers the 6-doc long split with headroom.
 EXTRACTBENCH_FILE_TIMEOUT_FLOOR = 1800.0
 DEFAULT_FILE_TIMEOUT_WINDOWS = 96
+# One extra batch so GLM variance (pueblo 706s vs 720s; W14 298s vs 240s)
+# does not kill a run that is already finishing.
+WINDOW_POOL_SLACK_BATCHES = 1
 _REF_PREFIXES = ("#/$defs/", "#/definitions/")
 
 
@@ -337,18 +340,20 @@ def extract_document_with_citations(
 
 
 def window_pool_timeout(n_windows: int, concurrency: int, timeout: float | None) -> float | None:
-    """Wall budget for a windowed extract: per-call timeout times batches.
+    """Wall budget for a windowed extract: per-call timeout times batches, plus slack.
 
     ``--timeout`` is per window. Collecting every future with that same value
     kills a 10-page doc at 240s even when each page would finish. Scale by
-    ``ceil(windows / concurrency)`` so Goshen / pueblo / Veralto can complete.
+    ``ceil(windows / concurrency) + 1`` so pueblo's ~706–800s 11-window run is
+    not killed at exactly 720s when GLM is a few tens of seconds slow.
     """
     if timeout is None:
         return None
     if n_windows <= 0:
         return timeout
     workers = max(1, min(int(concurrency), n_windows))
-    return timeout * math.ceil(n_windows / workers)
+    batches = math.ceil(n_windows / workers)
+    return timeout * (batches + WINDOW_POOL_SLACK_BATCHES)
 
 
 def extractbench_file_timeout(
@@ -420,8 +425,10 @@ def _extract_parse_windows(
     Each window is a single attempt. File-level ExtractBench retries still apply
     to transient errors; a hung window must not burn the 1800s per-file budget
     three times (pueblo / long on the 6-doc smoke). The pool wait is the
-    per-window timeout times the number of concurrent batches, not one 240s
-    wrap around the whole document.
+    per-window timeout times concurrent batches, plus one batch of slack, not
+    one 240s wrap around the whole document. Do not ``shutdown(wait=True)``
+    after a pool timeout: that is how long sat until the 96-window file cap
+    with no result.json.
     """
     sources = [_window_source(window) for window in windows]
     workers = max(1, min(window_concurrency, len(sources)))
@@ -437,24 +444,37 @@ def _extract_parse_windows(
         ) as extractor:
             return extractor.extract_with_usage(source, media_type=media_type)
 
-    if workers == 1:
+    budget = window_pool_timeout(len(sources), workers, timeout)
+    if budget is None:
         pairs = [_run(source, media_type) for source, media_type in sources]
     else:
-        budget = window_pool_timeout(len(sources), workers, timeout)
-        with ThreadPoolExecutor(max_workers=workers) as pool:
-            futures = [pool.submit(_run, source, media_type) for source, media_type in sources]
-            _done, pending = wait(futures, timeout=budget)
-            if pending:
-                for future in futures:
-                    future.cancel()
-                raise ModelError(
-                    f"Parse window timed out after {budget}s",
-                    retryable=False,
-                )
-            pairs = [future.result() for future in futures]
+        pairs = _run_window_pool(_run, sources, workers, budget)
     return [as_extracted_dict(part) for part, _usage in pairs], _sum_usage(
         usage for _part, usage in pairs
     )
+
+
+def _run_window_pool(
+    run: Callable[..., tuple[ExtractedDocument, Usage]],
+    sources: list[tuple[bytes, str]],
+    workers: int,
+    budget: float,
+) -> list[tuple[ExtractedDocument, Usage]]:
+    """Run windows concurrently and return as soon as the budget expires."""
+    pool = ThreadPoolExecutor(max_workers=workers)
+    try:
+        futures = [pool.submit(run, source, media_type) for source, media_type in sources]
+        _done, pending = wait(futures, timeout=budget)
+        if pending:
+            for future in futures:
+                future.cancel()
+            raise ModelError(
+                f"Parse window timed out after {budget}s",
+                retryable=False,
+            )
+        return [future.result() for future in futures]
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
 
 
 def _extractbench_retryable(exc: ModelError) -> bool:
@@ -794,7 +814,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_CALL_TIMEOUT,
         help=(
             f"per-window model timeout in seconds (default: {int(DEFAULT_CALL_TIMEOUT)}); "
-            "document wall budget is timeout × ceil(windows / concurrency); "
+            "document wall is timeout × (ceil(windows / concurrency) + 1); "
             "ExtractBench per-file timeout is max(1800, that budget for a long doc)"
         ),
     )

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -22,6 +22,7 @@ import os
 import re
 import subprocess
 import sys
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import Any
@@ -72,6 +73,11 @@ DEFAULT_INSTRUCTIONS = (
 DEFAULT_MAX_INPUT_BYTES = 500 * 1024 * 1024
 DEFAULT_CALL_TIMEOUT = 240.0
 DEFAULT_WINDOW_CONCURRENCY = 4
+# ExtractBench InferenceRunner wraps each file at 1800s and retries twice.
+# Window-pool wait for Veralto (41) / long (66) is above that, so the file
+# cap must be ≥ pool budget. 96 windows covers the 6-doc long split with headroom.
+EXTRACTBENCH_FILE_TIMEOUT_FLOOR = 1800.0
+DEFAULT_FILE_TIMEOUT_WINDOWS = 96
 _REF_PREFIXES = ("#/$defs/", "#/definitions/")
 
 
@@ -345,6 +351,50 @@ def window_pool_timeout(n_windows: int, concurrency: int, timeout: float | None)
     return timeout * math.ceil(n_windows / workers)
 
 
+def extractbench_file_timeout(
+    n_windows: int,
+    concurrency: int,
+    timeout: float | None,
+    *,
+    floor: float = EXTRACTBENCH_FILE_TIMEOUT_FLOOR,
+) -> float | None:
+    """Per-file ExtractBench cap: at least the window-pool wait, never below ``floor``.
+
+    The runner's 1800s wrap is independent of ``window_pool_timeout``. A 1-page
+    call can still take longer than ``--timeout`` (W14 ~298s at 240s), so keep
+    the 1800s floor; raise it when the pool budget is larger (Veralto / long).
+    """
+    pool = window_pool_timeout(n_windows, concurrency, timeout)
+    if pool is None:
+        return None
+    return max(pool, floor)
+
+
+def bind_inference_timeouts(
+    run: Callable[..., Any],
+    per_file_timeout: float | None,
+    timeout_retries: int = 0,
+) -> Callable[..., Any]:
+    """Force ExtractBench inference to use our file timeout and no timeout retries."""
+
+    def bound(self: object, *args: Any, **kwargs: Any) -> Any:
+        if per_file_timeout is not None:
+            kwargs["per_file_timeout"] = per_file_timeout
+        kwargs["timeout_retries"] = timeout_retries
+        return run(self, *args, **kwargs)
+
+    bound.__wrapped__ = run  # type: ignore[attr-defined]
+    return bound
+
+
+def _bind_extractbench_timeouts(per_file_timeout: float | None, timeout_retries: int = 0) -> None:
+    """Patch ExtractBench's inference CLI so ``cli.run`` cannot 3×1800s a file."""
+    from extract_bench.inference.cli import InferenceCLI
+
+    original = getattr(InferenceCLI.run, "__wrapped__", InferenceCLI.run)
+    InferenceCLI.run = bind_inference_timeouts(original, per_file_timeout, timeout_retries)
+
+
 def _window_source(window: object) -> tuple[bytes, str]:
     """Encode one parse window as model input. Never send a raw PDF."""
     if getattr(window, "has_text", lambda: False)():
@@ -576,6 +626,10 @@ def register_openextract_pipeline(
     from extract_bench.schemas.product import ProductType
 
     name = pipeline_name_for_model(model, pipeline_name)
+    file_timeout = extractbench_file_timeout(
+        DEFAULT_FILE_TIMEOUT_WINDOWS, window_concurrency, timeout
+    )
+    _bind_extractbench_timeouts(file_timeout, timeout_retries=0)
     config = {
         "model": model,
         "instructions": instructions,
@@ -700,6 +754,7 @@ def register_openextract_pipeline(
     try:
         spec = get_pipeline(name)
         spec.config.update(config)
+        spec.per_file_timeout = file_timeout
     except ValueError:
         register_pipeline(
             PipelineSpec(
@@ -707,6 +762,7 @@ def register_openextract_pipeline(
                 provider_name="openextract",
                 product_type=ProductType.EXTRACT,
                 config=config,
+                per_file_timeout=file_timeout,
             )
         )
     return name
@@ -738,7 +794,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_CALL_TIMEOUT,
         help=(
             f"per-window model timeout in seconds (default: {int(DEFAULT_CALL_TIMEOUT)}); "
-            "document wall budget is timeout × ceil(windows / concurrency)"
+            "document wall budget is timeout × ceil(windows / concurrency); "
+            "ExtractBench per-file timeout is max(1800, that budget for a long doc)"
         ),
     )
     parser.add_argument(

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -17,12 +17,12 @@ from __future__ import annotations
 
 import argparse
 import copy
+import math
 import os
 import re
 import subprocess
 import sys
-from concurrent.futures import ThreadPoolExecutor
-from concurrent.futures import TimeoutError as FuturesTimeoutError
+from concurrent.futures import ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import Any
 
@@ -302,10 +302,11 @@ def extract_document_with_citations(
         schema = json_schema_with_citations(schema)
     run_source, run_media_type, parsed = _parse_then_extract_source(source, media_type)
     policy = RetryPolicy(max_retries=max_retries)
-    windows = parse_windows(parsed) if parsed is not None and parsed.has_text() else ()
-    if len(windows) > 1:
+    windows = parse_windows(parsed) if parsed is not None and parsed.pages else ()
+    scanned = parsed is not None and parsed.pages and not parsed.has_text()
+    if len(windows) > 1 or scanned:
         payloads, usage = _extract_parse_windows(
-            windows,
+            windows or (parsed,),
             model,
             schema,
             run_instructions,
@@ -329,6 +330,31 @@ def extract_document_with_citations(
     return data, usage, citations
 
 
+def window_pool_timeout(n_windows: int, concurrency: int, timeout: float | None) -> float | None:
+    """Wall budget for a windowed extract: per-call timeout times batches.
+
+    ``--timeout`` is per window. Collecting every future with that same value
+    kills a 10-page doc at 240s even when each page would finish. Scale by
+    ``ceil(windows / concurrency)`` so Goshen / pueblo / Veralto can complete.
+    """
+    if timeout is None:
+        return None
+    if n_windows <= 0:
+        return timeout
+    workers = max(1, min(int(concurrency), n_windows))
+    return timeout * math.ceil(n_windows / workers)
+
+
+def _window_source(window: object) -> tuple[bytes, str]:
+    """Encode one parse window as model input. Never send a raw PDF."""
+    if getattr(window, "has_text", lambda: False)():
+        return window.as_prompt_text().encode("utf-8"), "text/plain"
+    image = next((page.image for page in getattr(window, "pages", ()) if page.image), None)
+    if image is not None:
+        return image, "image/png"
+    return window.as_prompt_text().encode("utf-8"), "text/plain"
+
+
 def _extract_parse_windows(
     windows: tuple,
     model: str | object,
@@ -343,13 +369,15 @@ def _extract_parse_windows(
 
     Each window is a single attempt. File-level ExtractBench retries still apply
     to transient errors; a hung window must not burn the 1800s per-file budget
-    three times (pueblo / long on the 6-doc smoke).
+    three times (pueblo / long on the 6-doc smoke). The pool wait is the
+    per-window timeout times the number of concurrent batches, not one 240s
+    wrap around the whole document.
     """
-    sources = [window.as_prompt_text().encode("utf-8") for window in windows]
+    sources = [_window_source(window) for window in windows]
     workers = max(1, min(window_concurrency, len(sources)))
     once = RetryPolicy(max_retries=0)
 
-    def _run(source: bytes) -> tuple[ExtractedDocument, Usage]:
+    def _run(source: bytes, media_type: str) -> tuple[ExtractedDocument, Usage]:
         agent = _build_schema_agent(model, schema, instructions, timeout=timeout)
         with Extractor(
             ExtractedDocument,
@@ -357,25 +385,23 @@ def _extract_parse_windows(
             retry_policy=once,
             max_input_bytes=max_input_bytes,
         ) as extractor:
-            return extractor.extract_with_usage(source, media_type="text/plain")
+            return extractor.extract_with_usage(source, media_type=media_type)
 
     if workers == 1:
-        pairs = [_run(source) for source in sources]
+        pairs = [_run(source, media_type) for source, media_type in sources]
     else:
+        budget = window_pool_timeout(len(sources), workers, timeout)
         with ThreadPoolExecutor(max_workers=workers) as pool:
-            futures = [pool.submit(_run, source) for source in sources]
-            try:
-                pairs = [
-                    future.result() if timeout is None else future.result(timeout=timeout)
-                    for future in futures
-                ]
-            except FuturesTimeoutError as exc:
+            futures = [pool.submit(_run, source, media_type) for source, media_type in sources]
+            _done, pending = wait(futures, timeout=budget)
+            if pending:
                 for future in futures:
                     future.cancel()
                 raise ModelError(
-                    f"Parse window timed out after {timeout}s",
+                    f"Parse window timed out after {budget}s",
                     retryable=False,
-                ) from exc
+                )
+            pairs = [future.result() for future in futures]
     return [as_extracted_dict(part) for part, _usage in pairs], _sum_usage(
         usage for _part, usage in pairs
     )
@@ -407,12 +433,19 @@ def _merge_window_payloads(
 def _parse_then_extract_source(
     source: Path | str | bytes, media_type: str | None
 ) -> tuple[Path | str | bytes, str | None, object]:
-    """Load bytes, parse locally, and feed page-indexed text when it exists."""
+    """Load bytes, parse locally, and feed text or page images — never a PDF upload."""
     data, resolved_type = _source_bytes(source, media_type)
     parsed_inputs, parsed = maybe_parsed_inputs(data, resolved_type or "", parse=True)
-    if parsed_inputs is None:
-        return source, media_type or resolved_type, parsed
-    return parsed_inputs[1].encode("utf-8"), "text/plain", parsed
+    if parsed is not None and parsed.has_text() and parsed_inputs is not None:
+        text = parsed_inputs[1]
+        if isinstance(text, str):
+            return text.encode("utf-8"), "text/plain", parsed
+    if parsed is not None and parsed.has_images():
+        image = next(page.image for page in parsed.pages if page.image)
+        return image, "image/png", parsed
+    if parsed is not None and parsed.pages and not parsed.has_text():
+        return parsed.as_prompt_text().encode("utf-8"), "text/plain", parsed
+    return source, media_type or resolved_type, parsed
 
 
 def _source_bytes(source: Path | str | bytes, media_type: str | None) -> tuple[bytes, str | None]:
@@ -703,7 +736,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--timeout",
         type=float,
         default=DEFAULT_CALL_TIMEOUT,
-        help=f"per-window model timeout in seconds (default: {int(DEFAULT_CALL_TIMEOUT)})",
+        help=(
+            f"per-window model timeout in seconds (default: {int(DEFAULT_CALL_TIMEOUT)}); "
+            "document wall budget is timeout × ceil(windows / concurrency)"
+        ),
     )
     parser.add_argument(
         "--window-concurrency",

--- a/src/openextract/_agent.py
+++ b/src/openextract/_agent.py
@@ -113,6 +113,7 @@ def _build_agent(
             output_type = NativeOutput(schema)
         capabilities, compatibility_kwargs = _instrumentation_capabilities(instrument)
         capabilities = [*capabilities, *extra_capabilities]
+        _ensure_openai_usage_fallback()
         routed_model = _route_model(model) if isinstance(model, str) else model
         agent_kwargs: dict[str, object] = {
             "instructions": instructions,
@@ -167,6 +168,7 @@ _INPUT_TOKEN_KEYS = (
     "promptTokens",
     "native_tokens_prompt",
     "native_tokens_input",
+    "tokens_prompt",
 )
 _OUTPUT_TOKEN_KEYS = (
     "output_tokens",
@@ -176,9 +178,51 @@ _OUTPUT_TOKEN_KEYS = (
     "completionTokens",
     "native_tokens_completion",
     "native_tokens_output",
+    "tokens_completion",
 )
-_TOTAL_TOKEN_KEYS = ("total_tokens", "totalTokens", "native_tokens_total")
-_USAGE_NEST_KEYS = ("details", "usage", "provider_details", "extra", "raw", "body")
+_TOTAL_TOKEN_KEYS = ("total_tokens", "totalTokens", "native_tokens_total", "tokens_total")
+_USAGE_NEST_KEYS = (
+    "details",
+    "usage",
+    "provider_details",
+    "provider_response",
+    "request_usage",
+    "extra",
+    "raw",
+    "body",
+)
+_OPENAI_USAGE_PATCHED = False
+
+
+def _ensure_openai_usage_fallback() -> None:
+    """Copy provider ``prompt_tokens`` when genai-prices extract leaves zeros.
+
+    pydantic-ai ``RequestUsage.extract`` drops OpenRouter ``prompt_tokens`` /
+    ``completion_tokens`` unless genai-prices recognizes the model. Live
+    GLM-5.3-flash then records 0/0/0 even though the provider sent counts.
+    """
+    global _OPENAI_USAGE_PATCHED
+    if _OPENAI_USAGE_PATCHED:
+        return
+    try:
+        from pydantic_ai.models import openai as openai_mod
+    except ImportError:
+        return
+    original = openai_mod._map_usage
+
+    def _map_usage_with_fallback(response, provider, provider_url, model):  # noqa: ANN001
+        mapped = original(response, provider, provider_url, model)
+        if mapped.input_tokens or mapped.output_tokens:
+            return mapped
+        found = _usage_from_raw(getattr(response, "usage", None))
+        if not (found.input_tokens or found.output_tokens):
+            return mapped
+        mapped.input_tokens = found.input_tokens
+        mapped.output_tokens = found.output_tokens
+        return mapped
+
+    openai_mod._map_usage = _map_usage_with_fallback  # ty: ignore[invalid-assignment]
+    _OPENAI_USAGE_PATCHED = True
 
 
 def _usage_model_settings(
@@ -192,6 +236,7 @@ def _usage_model_settings(
     """
     if not (isinstance(model, str) and model.startswith("openrouter")):
         return model_settings
+    _ensure_openai_usage_fallback()
     merged = dict(model_settings) if model_settings is not None else {}
     merged.setdefault("openrouter_usage", {"include": True})
     extra = dict(merged["extra_body"]) if isinstance(merged.get("extra_body"), dict) else {}
@@ -250,9 +295,14 @@ def _usage_from_raw_depth(raw: object, depth: int) -> Usage:
         return Usage(0, 0, 0)
     if isinstance(raw, Usage):
         return raw
+    dumped = _maybe_model_dump(raw)
     input_tokens = _token_count(raw, _INPUT_TOKEN_KEYS)
     output_tokens = _token_count(raw, _OUTPUT_TOKEN_KEYS)
     total_tokens = _token_count(raw, _TOTAL_TOKEN_KEYS)
+    if input_tokens == 0 and output_tokens == 0 and dumped is not None:
+        input_tokens = _token_count(dumped, _INPUT_TOKEN_KEYS)
+        output_tokens = _token_count(dumped, _OUTPUT_TOKEN_KEYS)
+        total_tokens = _token_count(dumped, _TOTAL_TOKEN_KEYS)
     if input_tokens == 0 and output_tokens == 0:
         for key in _USAGE_NEST_KEYS:
             nested = _nested_usage_container(raw, key)
@@ -261,9 +311,27 @@ def _usage_from_raw_depth(raw: object, depth: int) -> Usage:
             found = _usage_from_raw_depth(nested, depth + 1)
             if found.input_tokens or found.output_tokens or found.total_tokens:
                 return found
+        if dumped is not None:
+            found = _usage_from_raw_depth(dumped, depth + 1)
+            if found.input_tokens or found.output_tokens or found.total_tokens:
+                return found
     if total_tokens == 0:
         total_tokens = input_tokens + output_tokens
     return Usage(input_tokens, output_tokens, total_tokens)
+
+
+def _maybe_model_dump(raw: object) -> dict[str, object] | None:
+    dumper = getattr(raw, "model_dump", None)
+    if not callable(dumper):
+        return None
+    try:
+        dumped = dumper(exclude_none=True)
+    except TypeError:
+        try:
+            dumped = dumper()
+        except TypeError:
+            return None
+    return dumped if isinstance(dumped, dict) else None
 
 
 def _maybe_call(value: object) -> object:
@@ -291,19 +359,31 @@ def _extract_usage_object(result: object) -> object:
     return result
 
 
+def _message_usage_parts(message: object) -> list[object]:
+    return [
+        getattr(message, "usage", None),
+        getattr(message, "provider_details", None),
+        getattr(message, "provider_response", None),
+    ]
+
+
 def _usage_candidates(result: object) -> list[object]:
     """Collect usage-bearing objects from a pydantic-ai run result."""
     found: list[object] = [_extract_usage_object(result)]
-    response = getattr(result, "response", None)
-    descriptor = getattr(type(result), "response", None)
-    if response is not None and descriptor is not None and not callable(descriptor):
+    found.append(getattr(result, "provider_response", None))
+    try:
+        response = _maybe_call(getattr(result, "response", None))
+    except (ValueError, AttributeError):
+        response = None
+    if response is not None and response is not result:
         found.append(getattr(response, "usage", None))
         found.append(getattr(response, "provider_details", None))
-    messages = _maybe_call(getattr(result, "all_messages", None))
-    if isinstance(messages, list):
-        for message in messages:
-            found.append(getattr(message, "usage", None))
-            found.append(getattr(message, "provider_details", None))
+        found.append(getattr(response, "provider_response", None))
+    for getter in ("all_messages", "new_messages"):
+        messages = _maybe_call(getattr(result, getter, None))
+        if isinstance(messages, list):
+            for message in messages:
+                found.extend(_message_usage_parts(message))
     return found
 
 

--- a/src/openextract/_parse.py
+++ b/src/openextract/_parse.py
@@ -1,9 +1,11 @@
-"""Local parse-then-extract: page text and parser-backed boxes."""
+"""Local parse-then-extract: page text, page images, and parser-backed boxes."""
 
 from __future__ import annotations
 
 import math
+import struct
 import threading
+import zlib
 from collections.abc import Iterator
 from dataclasses import dataclass
 from difflib import SequenceMatcher
@@ -45,6 +47,7 @@ class ParsedPage:
     width: float
     height: float
     spans: tuple[ParsedSpan, ...]
+    image: bytes | None = None
 
 
 @dataclass(frozen=True)
@@ -55,6 +58,9 @@ class ParsedDocument:
 
     def has_text(self) -> bool:
         return any(page.text.strip() for page in self.pages)
+
+    def has_images(self) -> bool:
+        return any(page.image for page in self.pages)
 
     def as_prompt_text(self) -> str:
         """Render page markers so the model can cite 1-indexed pages."""
@@ -79,6 +85,25 @@ def parsed_run_inputs(parsed: ParsedDocument) -> list[str]:
         "Page boundaries are marked as '--- Page N ---' (1-indexed).",
         parsed.as_prompt_text(),
     ]
+
+
+def parsed_image_inputs(parsed: ParsedDocument) -> list:
+    """Prompt inputs that send locally rendered page images, never the PDF.
+
+    ``BinaryContent`` is imported here so ``import openextract`` stays
+    pydantic-ai-free (see ``test_package_import_defers_pydantic_ai_runtime``).
+    """
+    from pydantic_ai import BinaryContent
+
+    parts: list = [
+        "Extract the requested information from this document. "
+        "Page images follow in 1-indexed order, marked as '--- Page N ---'."
+    ]
+    for page in parsed.pages:
+        parts.append(_PAGE_HEADER.format(page=page.page))
+        if page.image:
+            parts.append(BinaryContent(data=page.image, media_type="image/png"))
+    return parts
 
 
 def _page_block(page: ParsedPage) -> str:
@@ -158,6 +183,7 @@ def _split_page(page: ParsedPage, budget: int) -> tuple[ParsedPage, ...]:
                 width=page.width,
                 height=page.height,
                 spans=page.spans,
+                image=page.image,
             )
         )
         start = end
@@ -176,8 +202,13 @@ def parsed_window_inputs(
     One window keeps the original inputs object so callers that patch
     ``_extract_once`` still see a single call with the prepared prompt.
     """
-    if parsed is None or not parsed.has_text():
+    if parsed is None or not parsed.pages:
         return [fallback_inputs]
+    if not parsed.has_text():
+        windows = parse_windows(parsed, max_chars=max_chars, max_pages=max_pages)
+        if parsed.has_images():
+            return [parsed_image_inputs(window) for window in windows]
+        return [parsed_run_inputs(window) for window in windows]
     windows = parse_windows(parsed, max_chars=max_chars, max_pages=max_pages)
     if len(windows) == 1:
         return [fallback_inputs]
@@ -189,10 +220,22 @@ def maybe_parsed_inputs(
     file_type: str,
     *,
     parse: bool,
-) -> tuple[list[str] | None, ParsedDocument | None]:
-    """Return page-indexed prompt inputs when a local parse has text."""
+) -> tuple[list | None, ParsedDocument | None]:
+    """Return page-indexed prompt inputs when a local parse can replace the file.
+
+    Text PDFs become page-marked strings. Scanned / empty-text PDFs become
+    locally rendered page images (or page headers if render failed). Never
+    returns ``None`` inputs for a paginated parse — that would upload the PDF
+    to the provider's document-parse engine.
+    """
     parsed = try_parse_document(file_bytes, file_type) if parse else None
-    if parsed is not None and parsed.has_text():
+    if parsed is None:
+        return None, None
+    if parsed.has_text():
+        return parsed_run_inputs(parsed), parsed
+    if parsed.has_images():
+        return parsed_image_inputs(parsed), parsed
+    if parsed.pages:
         return parsed_run_inputs(parsed), parsed
     return None, parsed
 
@@ -263,7 +306,97 @@ def _parse_pdf_page(pdf: Any, index: int) -> ParsedPage:
         close = getattr(textpage, "close", None)
         if callable(close):
             close()
-    return ParsedPage(page=index + 1, text=text, width=width, height=height, spans=spans)
+    image = None if text.strip() else _render_page_png(page)
+    return ParsedPage(
+        page=index + 1, text=text, width=width, height=height, spans=spans, image=image
+    )
+
+
+def _render_page_png(page: Any) -> bytes | None:
+    """Rasterize one PDF page to PNG. Callers must hold ``_PDFIUM_LOCK``."""
+    render = getattr(page, "render", None)
+    if not callable(render):
+        return None
+    try:
+        bitmap = render(scale=2, rev_byteorder=True)
+    except TypeError:
+        try:
+            bitmap = render(scale=2)
+        except Exception:
+            return None
+    except Exception:
+        return None
+    try:
+        return _bitmap_to_png(bitmap)
+    finally:
+        close = getattr(bitmap, "close", None)
+        if callable(close):
+            close()
+
+
+def _bitmap_to_png(bitmap: Any) -> bytes | None:
+    width = int(getattr(bitmap, "width", 0) or 0)
+    height = int(getattr(bitmap, "height", 0) or 0)
+    mode = str(getattr(bitmap, "mode", "") or "")
+    channels = int(getattr(bitmap, "n_channels", 0) or 0) or _channels_for_mode(mode)
+    stride = int(getattr(bitmap, "stride", 0) or 0)
+    buffer = getattr(bitmap, "buffer", None)
+    if width <= 0 or height <= 0 or buffer is None or channels not in {1, 3, 4}:
+        return None
+    if stride < width * channels:
+        return None
+    raw = bytes(buffer)
+    row = width * channels
+    packed = bytearray(height * row)
+    swap = mode.startswith("BGR")
+    for y in range(height):
+        src = raw[y * stride : y * stride + row]
+        dest = y * row
+        if swap and channels >= 3:
+            for x in range(width):
+                i, j = x * channels, dest + x * channels
+                packed[j] = src[i + 2]
+                packed[j + 1] = src[i + 1]
+                packed[j + 2] = src[i]
+                if channels == 4:
+                    packed[j + 3] = src[i + 3]
+        else:
+            packed[dest : dest + row] = src
+    return _encode_png(width, height, bytes(packed), channels)
+
+
+def _channels_for_mode(mode: str) -> int:
+    if mode in {"L", "gray", "GRAY"}:
+        return 1
+    if mode in {"RGB", "BGR"}:
+        return 3
+    if mode in {"RGBA", "BGRA", "RGBx", "BGRx"}:
+        return 4
+    return 0
+
+
+def _encode_png(width: int, height: int, pixels: bytes, channels: int) -> bytes:
+    color_type = {1: 0, 3: 2, 4: 6}[channels]
+    raw = bytearray()
+    row = width * channels
+    for y in range(height):
+        raw.append(0)
+        raw.extend(pixels[y * row : (y + 1) * row])
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return (
+            struct.pack(">I", len(data))
+            + tag
+            + data
+            + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+        )
+
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, color_type, 0, 0, 0))
+        + chunk(b"IDAT", zlib.compress(bytes(raw), 6))
+        + chunk(b"IEND", b"")
+    )
 
 
 def _page_size(page: Any) -> tuple[float, float]:

--- a/src/openextract/_parse.py
+++ b/src/openextract/_parse.py
@@ -25,6 +25,9 @@ _FUZZY_RATIO = 0.85
 # split; an oversized page is still sliced by the char budget.
 DEFAULT_PARSE_WINDOW_CHARS = 12_000
 DEFAULT_PARSE_WINDOW_PAGES = 1
+# Long-edge cap for scanned page rasters. scale=2 letter PNGs were ~400KB and
+# token-limited GLM one page at a time; boxes stay on the PDF page, not pixels.
+DEFAULT_RENDER_MAX_EDGE = 768
 # pypdfium2 / PDFium is not safe across threads in one process.
 _PDFIUM_LOCK = threading.Lock()
 
@@ -312,16 +315,32 @@ def _parse_pdf_page(pdf: Any, index: int) -> ParsedPage:
     )
 
 
+def _render_scale(width: float, height: float, max_edge: int = DEFAULT_RENDER_MAX_EDGE) -> float:
+    """Scale that fits the page in ``max_edge`` pixels without upscaling."""
+    longest = max(width, height)
+    if longest <= 0:
+        return 1.0
+    return min(1.0, max_edge / longest)
+
+
 def _render_page_png(page: Any) -> bytes | None:
-    """Rasterize one PDF page to PNG. Callers must hold ``_PDFIUM_LOCK``."""
+    """Rasterize one PDF page to a compact grayscale PNG.
+
+    Callers must hold ``_PDFIUM_LOCK``.
+    """
     render = getattr(page, "render", None)
     if not callable(render):
         return None
     try:
-        bitmap = render(scale=2, rev_byteorder=True)
+        width, height = _page_size(page)
+        scale = _render_scale(width, height)
+    except Exception:
+        scale = 1.0
+    try:
+        bitmap = render(scale=scale, rev_byteorder=True)
     except TypeError:
         try:
-            bitmap = render(scale=2)
+            bitmap = render(scale=scale)
         except Exception:
             return None
     except Exception:
@@ -362,7 +381,19 @@ def _bitmap_to_png(bitmap: Any) -> bytes | None:
                     packed[j + 3] = src[i + 3]
         else:
             packed[dest : dest + row] = src
-    return _encode_png(width, height, bytes(packed), channels)
+    luma, luma_channels = _luma_pixels(bytes(packed), width, height, channels)
+    return _encode_png(width, height, luma, luma_channels)
+
+
+def _luma_pixels(pixels: bytes, width: int, height: int, channels: int) -> tuple[bytes, int]:
+    """Convert packed RGB(A) to 8-bit grayscale. 1-channel input is returned as-is."""
+    if channels == 1:
+        return pixels, 1
+    out = bytearray(width * height)
+    for index in range(width * height):
+        offset = index * channels
+        out[index] = (pixels[offset] * 77 + pixels[offset + 1] * 150 + pixels[offset + 2] * 29) >> 8
+    return bytes(out), 1
 
 
 def _channels_for_mode(mode: str) -> int:
@@ -394,7 +425,7 @@ def _encode_png(width: int, height: int, pixels: bytes, channels: int) -> bytes:
     return (
         b"\x89PNG\r\n\x1a\n"
         + chunk(b"IHDR", struct.pack(">IIBBBBB", width, height, 8, color_type, 0, 0, 0))
-        + chunk(b"IDAT", zlib.compress(bytes(raw), 6))
+        + chunk(b"IDAT", zlib.compress(bytes(raw), 9))
         + chunk(b"IEND", b"")
     )
 

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1805,6 +1805,118 @@ class TestExtractWithUsage:
         too_deep = {"details": {"details": {"details": {"details": {"details": {}}}}}}
         too_deep["details"]["details"]["details"]["details"]["details"]["prompt_tokens"] = 5
         assert _usage_from_raw(too_deep) == Usage(0, 0, 0)
+        assert _usage_from_raw({"tokens_prompt": 40, "tokens_completion": 2}) == Usage(40, 2, 42)
+
+        class _Dumped:
+            input_tokens = 0
+            output_tokens = 0
+
+            def model_dump(self, exclude_none=True):
+                return {"prompt_tokens": 77, "completion_tokens": 3}
+
+        assert _usage_from_raw(_Dumped()) == Usage(77, 3, 80)
+
+        class _DumpNeedsNoKwargs:
+            def model_dump(self):
+                return {"prompt_tokens": 5, "completion_tokens": 1}
+
+        assert _usage_from_raw(_DumpNeedsNoKwargs()) == Usage(5, 1, 6)
+
+        class _DumpBroken:
+            def model_dump(self, extra):
+                return extra
+
+        assert _usage_from_raw(_DumpBroken()) == Usage(0, 0, 0)
+
+        class _DumpList:
+            def model_dump(self, exclude_none=True):
+                return [1]
+
+        assert _usage_from_raw(_DumpList()) == Usage(0, 0, 0)
+
+        class _DumpNoTokenAliases:
+            def model_dump(self, exclude_none=True):
+                return {"details": {}}
+
+        assert _usage_from_raw(_DumpNoTokenAliases()) == Usage(0, 0, 0)
+
+        class _NestedDump:
+            input_tokens = 0
+            output_tokens = 0
+
+            def model_dump(self, exclude_none=True):
+                return {"details": {"prompt_tokens": 8, "completion_tokens": 1}}
+
+        assert _usage_from_raw(_NestedDump()) == Usage(8, 1, 9)
+
+        class _LiveProviderResponse:
+            @property
+            def usage(self):
+                return SimpleNamespace(input_tokens=0, output_tokens=0, total_tokens=0)
+
+            def all_messages(self):
+                return [
+                    SimpleNamespace(
+                        usage=SimpleNamespace(input_tokens=0, output_tokens=0),
+                        provider_details={},
+                        provider_response=SimpleNamespace(
+                            usage=SimpleNamespace(prompt_tokens=321, completion_tokens=7)
+                        ),
+                    )
+                ]
+
+        assert _usage_from_result(_LiveProviderResponse()) == Usage(321, 7, 328)
+
+        class _EmptyResponse:
+            @property
+            def response(self):
+                raise ValueError("No response found")
+
+        assert _usage_from_result(_EmptyResponse()) == Usage(0, 0, 0)
+
+    def test_openai_usage_fallback_reads_provider_prompt_tokens(self, monkeypatch):
+        from pydantic_ai.models import openai as openai_mod
+
+        import openextract._agent as agent_mod
+
+        class _Mapped:
+            def __init__(self, inp=0, out=0):
+                self.input_tokens = inp
+                self.output_tokens = out
+
+        monkeypatch.setattr(agent_mod, "_OPENAI_USAGE_PATCHED", False)
+        monkeypatch.setattr(openai_mod, "_map_usage", lambda *_a, **_k: _Mapped())
+        agent_mod._ensure_openai_usage_fallback()
+        agent_mod._ensure_openai_usage_fallback()
+        filled = openai_mod._map_usage(
+            SimpleNamespace(usage=SimpleNamespace(prompt_tokens=99, completion_tokens=4)),
+            "openrouter",
+            "https://openrouter.ai/api/v1",
+            "z-ai/glm-5.3-flash",
+        )
+        assert (filled.input_tokens, filled.output_tokens) == (99, 4)
+        empty = openai_mod._map_usage(SimpleNamespace(usage=None), "openrouter", "https://x", "m")
+        assert (empty.input_tokens, empty.output_tokens) == (0, 0)
+
+        monkeypatch.setattr(agent_mod, "_OPENAI_USAGE_PATCHED", False)
+        monkeypatch.setattr(openai_mod, "_map_usage", lambda *_a, **_k: _Mapped(5, 1))
+        agent_mod._ensure_openai_usage_fallback()
+        kept = openai_mod._map_usage(SimpleNamespace(usage=None), "openrouter", "https://x", "m")
+        assert (kept.input_tokens, kept.output_tokens) == (5, 1)
+
+        monkeypatch.setattr(agent_mod, "_OPENAI_USAGE_PATCHED", False)
+        real_import = __import__
+
+        def _boom(name, globals=None, locals=None, fromlist=(), level=0):
+            if name == "pydantic_ai.models" and fromlist and "openai" in fromlist:
+                raise ImportError("no openai extra")
+            return real_import(name, globals, locals, fromlist, level)
+
+        import builtins
+
+        monkeypatch.setattr(builtins, "__import__", _boom)
+        agent_mod._ensure_openai_usage_fallback()
+        assert agent_mod._OPENAI_USAGE_PATCHED is False
 
     def test_propagates_runtime_error_as_extraction_error(self, tmp_path, mocker):
         local = tmp_path / "input.txt"

--- a/tests/test_extractbench.py
+++ b/tests/test_extractbench.py
@@ -328,6 +328,131 @@ def test_extractbench_does_not_retry_timeouts():
     assert not extractbench._extractbench_retryable(ModelError("token limit", retryable=False))
 
 
+def test_window_pool_timeout_scales_with_batches():
+    assert extractbench.window_pool_timeout(10, 4, 240.0) == 720.0
+    assert extractbench.window_pool_timeout(11, 4, 240.0) == 720.0
+    assert extractbench.window_pool_timeout(41, 4, 240.0) == 2640.0
+    assert extractbench.window_pool_timeout(1, 4, 240.0) == 240.0
+    assert extractbench.window_pool_timeout(0, 4, 240.0) == 240.0
+    assert extractbench.window_pool_timeout(8, 4, None) is None
+
+
+def test_windowed_extract_uses_batch_budget_not_one_timeout(monkeypatch, tmp_path):
+    import time
+
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    pdf = synthetic_pdf(pages=["page one", "page two", "page three"])
+    path = tmp_path / "goshen.pdf"
+    path.write_bytes(pdf)
+    original = extractbench.Extractor.extract_with_usage
+
+    def _slow(self, source, *, media_type=None):
+        time.sleep(0.12)
+        return original(self, source, media_type=media_type)
+
+    monkeypatch.setattr(extractbench.Extractor, "extract_with_usage", _slow)
+    data, usage, _citations = extractbench.extract_document_with_citations(
+        path,
+        schema,
+        TestModel(custom_output_args={"output": {"vendor": "Acme"}, "citations": []}),
+        max_retries=0,
+        cite=True,
+        timeout=0.2,
+        window_concurrency=2,
+    )
+    assert data["vendor"] == "Acme"
+    assert usage.input_tokens >= 0
+
+
+def test_scanned_pdf_does_not_upload_original(monkeypatch, tmp_path):
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    pdf = synthetic_pdf(pages=["", ""])
+    path = tmp_path / "bianco.pdf"
+    path.write_bytes(pdf)
+    media_types: list[str | None] = []
+    original = extractbench.Extractor.extract_with_usage
+
+    def _spy(self, source, *, media_type=None):
+        media_types.append(media_type)
+        payload = source if isinstance(source, bytes) else Path(source).read_bytes()
+        assert not payload.startswith(b"%PDF")
+        return original(self, source, media_type=media_type)
+
+    monkeypatch.setattr(extractbench.Extractor, "extract_with_usage", _spy)
+    data, usage, citations = extractbench.extract_document_with_citations(
+        path,
+        schema,
+        TestModel(custom_output_args={"output": {"vendor": "Acme"}, "citations": []}),
+        max_retries=0,
+        cite=True,
+    )
+    assert data["vendor"] == "Acme"
+    assert usage.input_tokens >= 0
+    assert media_types
+    assert all(kind == "image/png" for kind in media_types)
+    assert all(citation.bbox is None for citation in citations)
+    source, media_type, parsed = extractbench._parse_then_extract_source(pdf, "application/pdf")
+    assert media_type == "image/png"
+    assert isinstance(source, bytes) and source.startswith(b"\x89PNG")
+    assert parsed is not None and not parsed.has_text()
+
+
+def test_extractbench_records_provider_usage(monkeypatch, tmp_path):
+    from openextract import Usage
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    path = tmp_path / "w14.pdf"
+    path.write_bytes(synthetic_pdf("W14"))
+
+    def _usage(self, source, *, media_type=None):
+        return extractbench.ExtractedDocument.model_validate(
+            {"output": {"vendor": "Acme"}, "citations": []}
+        ), Usage(1280, 64, 1344)
+
+    monkeypatch.setattr(extractbench.Extractor, "extract_with_usage", _usage)
+    data, usage, _citations = extractbench.extract_document_with_citations(
+        path,
+        schema,
+        TestModel(custom_output_args={"output": {"vendor": "Acme"}, "citations": []}),
+        max_retries=0,
+        cite=True,
+    )
+    assert data["vendor"] == "Acme"
+    assert usage == Usage(1280, 64, 1344)
+
+
+def test_window_source_prefers_image_then_headers():
+    from openextract._parse import ParsedDocument, ParsedPage
+
+    text = ParsedDocument(pages=(ParsedPage(1, "Hello", 1, 1, ()),))
+    assert extractbench._window_source(text)[1] == "text/plain"
+    image = ParsedDocument(pages=(ParsedPage(1, "", 1, 1, (), image=b"\x89PNG-img"),))
+    payload, media_type = extractbench._window_source(image)
+    assert media_type == "image/png"
+    assert payload == b"\x89PNG-img"
+    headers = ParsedDocument(pages=(ParsedPage(1, "", 1, 1, ()),))
+    payload, media_type = extractbench._window_source(headers)
+    assert media_type == "text/plain"
+    assert b"--- Page 1 ---" in payload
+
+
 def test_window_pool_timeout_is_permanent(monkeypatch, tmp_path):
     import time
 

--- a/tests/test_extractbench.py
+++ b/tests/test_extractbench.py
@@ -329,22 +329,31 @@ def test_extractbench_does_not_retry_timeouts():
 
 
 def test_window_pool_timeout_scales_with_batches():
-    assert extractbench.window_pool_timeout(10, 4, 240.0) == 720.0
-    assert extractbench.window_pool_timeout(11, 4, 240.0) == 720.0
-    assert extractbench.window_pool_timeout(41, 4, 240.0) == 2640.0
-    assert extractbench.window_pool_timeout(1, 4, 240.0) == 240.0
+    assert extractbench.window_pool_timeout(10, 4, 240.0) == 960.0
+    assert extractbench.window_pool_timeout(11, 4, 240.0) == 960.0
+    assert extractbench.window_pool_timeout(41, 4, 240.0) == 2880.0
+    assert extractbench.window_pool_timeout(66, 4, 240.0) == 4320.0
+    assert extractbench.window_pool_timeout(1, 4, 240.0) == 480.0
     assert extractbench.window_pool_timeout(0, 4, 240.0) == 240.0
     assert extractbench.window_pool_timeout(8, 4, None) is None
+
+
+def test_window_pool_timeout_has_slack_for_pueblo():
+    """Pueblo finished in 705.8s then died at a sharp 720s; 800s must fit."""
+    pueblo = extractbench.window_pool_timeout(11, 4, 240.0)
+    assert pueblo is not None
+    assert pueblo >= 800.0
+    assert pueblo > 240.0 * 3
 
 
 def test_extractbench_file_timeout_covers_pool_and_keeps_floor():
     assert extractbench.extractbench_file_timeout(1, 4, 240.0) == 1800.0
     assert extractbench.extractbench_file_timeout(10, 4, 240.0) == 1800.0
-    assert extractbench.extractbench_file_timeout(41, 4, 240.0) == 2640.0
-    assert extractbench.extractbench_file_timeout(66, 4, 240.0) == 4080.0
+    assert extractbench.extractbench_file_timeout(41, 4, 240.0) == 2880.0
+    assert extractbench.extractbench_file_timeout(66, 4, 240.0) == 4320.0
     assert (
         extractbench.extractbench_file_timeout(extractbench.DEFAULT_FILE_TIMEOUT_WINDOWS, 4, 240.0)
-        == 5760.0
+        == 6000.0
     )
     assert extractbench.extractbench_file_timeout(66, 4, None) is None
 
@@ -509,6 +518,40 @@ def test_window_pool_timeout_is_permanent(monkeypatch, tmp_path):
             window_concurrency=2,
         )
     assert exc.value.retryable is False
+
+
+def test_window_pool_timeout_does_not_wait_on_cancelled_workers(monkeypatch, tmp_path):
+    import time
+
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    pdf = synthetic_pdf(pages=["AAAA page one", "BBBB page two"])
+    path = tmp_path / "hang.pdf"
+    path.write_bytes(pdf)
+    original = extractbench.Extractor.extract_with_usage
+
+    def _hang(self, source, *, media_type=None):
+        time.sleep(2.0)
+        return original(self, source, media_type=media_type)
+
+    monkeypatch.setattr(extractbench.Extractor, "extract_with_usage", _hang)
+    started = time.monotonic()
+    with pytest.raises(ModelError, match="timed out"):
+        extractbench.extract_document_with_citations(
+            path,
+            schema,
+            TestModel(custom_output_args={"output": {"vendor": "Acme"}, "citations": []}),
+            max_retries=0,
+            cite=True,
+            timeout=0.05,
+            window_concurrency=2,
+        )
+    assert time.monotonic() - started < 1.0
 
 
 def test_merge_window_payloads_keeps_later_citations():

--- a/tests/test_extractbench.py
+++ b/tests/test_extractbench.py
@@ -337,6 +337,31 @@ def test_window_pool_timeout_scales_with_batches():
     assert extractbench.window_pool_timeout(8, 4, None) is None
 
 
+def test_extractbench_file_timeout_covers_pool_and_keeps_floor():
+    assert extractbench.extractbench_file_timeout(1, 4, 240.0) == 1800.0
+    assert extractbench.extractbench_file_timeout(10, 4, 240.0) == 1800.0
+    assert extractbench.extractbench_file_timeout(41, 4, 240.0) == 2640.0
+    assert extractbench.extractbench_file_timeout(66, 4, 240.0) == 4080.0
+    assert (
+        extractbench.extractbench_file_timeout(extractbench.DEFAULT_FILE_TIMEOUT_WINDOWS, 4, 240.0)
+        == 5760.0
+    )
+    assert extractbench.extractbench_file_timeout(66, 4, None) is None
+
+
+def test_bind_inference_timeouts_disables_timeout_retries():
+    def _run(self, pipeline, **kwargs):
+        return kwargs
+
+    bound = extractbench.bind_inference_timeouts(_run, 4080.0, timeout_retries=0)
+    forced = bound(object(), "openextract", timeout_retries=2, per_file_timeout=1800.0)
+    assert forced["per_file_timeout"] == 4080.0
+    assert forced["timeout_retries"] == 0
+    left = extractbench.bind_inference_timeouts(_run, None, timeout_retries=0)(object(), "x")
+    assert left["timeout_retries"] == 0
+    assert "per_file_timeout" not in left
+
+
 def test_windowed_extract_uses_batch_budget_not_one_timeout(monkeypatch, tmp_path):
     import time
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -14,9 +14,12 @@ from openextract._parse import (
     ParsedPage,
     ParsedSpan,
     _bbox_for_quote,
+    _bitmap_to_png,
+    _channels_for_mode,
     _char_box,
     _char_text,
     _citation_from_value,
+    _encode_png,
     _find_in_text,
     _flush_word,
     _ground_one,
@@ -27,6 +30,7 @@ from openextract._parse import (
     _pages_prompt_len,
     _parse_pdf_page,
     _pdf_box_to_coco,
+    _render_page_png,
     _split_page,
     _union_coco,
     _union_pdf_boxes,
@@ -37,6 +41,7 @@ from openextract._parse import (
     ground_citations,
     maybe_parsed_inputs,
     parse_windows,
+    parsed_image_inputs,
     parsed_run_inputs,
     parsed_window_inputs,
     try_parse_document,
@@ -527,3 +532,125 @@ def test_extract_chunks_large_parse_via_extract_once(monkeypatch, mocker):
         assert isinstance(prompt, str)
         assert len(prompt) <= 200
         assert "--- Page " in prompt
+
+
+def test_empty_text_pdf_renders_page_images_not_file_upload():
+    from pydantic_ai import BinaryContent
+
+    data = synthetic_pdf(pages=["", ""])
+    parsed = try_parse_document(data, "application/pdf")
+    assert parsed is not None
+    assert not parsed.has_text()
+    assert parsed.has_images()
+    assert all(page.image and page.image.startswith(b"\x89PNG") for page in parsed.pages)
+    inputs, got = maybe_parsed_inputs(data, "application/pdf", parse=True)
+    assert got is parsed or (got is not None and got.has_images())
+    assert inputs is not None
+    pngs = [
+        part
+        for part in inputs
+        if isinstance(part, BinaryContent) and part.media_type == "image/png"
+    ]
+    assert pngs
+    assert all(
+        not (isinstance(part, BinaryContent) and part.media_type == "application/pdf")
+        for part in inputs
+    )
+    fallback = ["pdf-upload"]
+    windows = parsed_window_inputs(got, fallback)
+    assert windows[0] is not fallback
+    assert all(
+        any(isinstance(part, BinaryContent) and part.media_type == "image/png" for part in window)
+        for window in windows
+    )
+    headers_only = ParsedDocument(pages=(_page("", page=1), _page("", page=2)))
+    assert not headers_only.has_images()
+    header_windows = parsed_window_inputs(headers_only, fallback)
+    assert header_windows[0] is not fallback
+    assert all("--- Page " in window[1] for window in header_windows)
+    assert parsed_image_inputs(headers_only)[0].startswith("Extract")
+
+
+def test_render_and_png_helpers(monkeypatch):
+    assert _channels_for_mode("L") == 1
+    assert _channels_for_mode("RGB") == 3
+    assert _channels_for_mode("BGR") == 3
+    assert _channels_for_mode("BGRA") == 4
+    assert _channels_for_mode("nope") == 0
+    png = _encode_png(1, 1, b"\xff\x00\x00", 3)
+    assert png.startswith(b"\x89PNG")
+    assert _render_page_png(SimpleNamespace()) is None
+
+    class _BadRender:
+        def render(self, **_kwargs):
+            raise RuntimeError("render")
+
+    assert _render_page_png(_BadRender()) is None
+
+    class _TypeThenFail:
+        def render(self, **kwargs):
+            if "rev_byteorder" in kwargs:
+                raise TypeError("no rev")
+            raise RuntimeError("still no")
+
+    assert _render_page_png(_TypeThenFail()) is None
+
+    class _TypeThenOk:
+        def render(self, **kwargs):
+            if "rev_byteorder" in kwargs:
+                raise TypeError("no rev")
+            return SimpleNamespace(
+                width=1, height=1, mode="BGR", n_channels=3, stride=3, buffer=b"\x00\x11\x22"
+            )
+
+    assert _render_page_png(_TypeThenOk()).startswith(b"\x89PNG")
+    assert _bitmap_to_png(SimpleNamespace(width=0, height=1, buffer=b"x")) is None
+    tight = SimpleNamespace(width=1, height=1, mode="RGB", n_channels=3, stride=1, buffer=b"abc")
+    assert _bitmap_to_png(tight) is None
+    rgba = SimpleNamespace(
+        width=1, height=1, mode="BGRA", n_channels=4, stride=4, buffer=b"\x01\x02\x03\x04"
+    )
+    assert _bitmap_to_png(rgba).startswith(b"\x89PNG")
+    gray = SimpleNamespace(width=1, height=1, mode="L", n_channels=0, stride=1, buffer=b"\x80")
+    assert _bitmap_to_png(gray).startswith(b"\x89PNG")
+
+    class _Closeable:
+        closed = False
+
+        def close(self):
+            self.closed = True
+
+    bitmap = _Closeable()
+    bitmap.width = 1
+    bitmap.height = 1
+    bitmap.mode = "RGB"
+    bitmap.n_channels = 3
+    bitmap.stride = 3
+    bitmap.buffer = b"\x10\x20\x30"
+
+    class _Page:
+        def render(self, **_kwargs):
+            return bitmap
+
+    assert _render_page_png(_Page()).startswith(b"\x89PNG")
+    assert bitmap.closed is True
+
+
+def test_maybe_parsed_inputs_headers_when_scan_has_no_image(monkeypatch):
+    empty = ParsedDocument(pages=(_page("", page=1),))
+    monkeypatch.setattr("openextract._parse.try_parse_document", lambda *_a, **_k: empty)
+    inputs, parsed = maybe_parsed_inputs(b"%PDF", "application/pdf", parse=True)
+    assert parsed is empty
+    assert inputs == parsed_run_inputs(empty)
+    none = ParsedDocument(pages=())
+    monkeypatch.setattr("openextract._parse.try_parse_document", lambda *_a, **_k: none)
+    assert maybe_parsed_inputs(b"%PDF", "application/pdf", parse=True) == (None, none)
+
+
+def test_split_page_keeps_image_bytes():
+    page = ParsedPage(
+        page=1, text="aaaa bbbb cccc dddd", width=1, height=1, spans=(), image=b"\x89PNG"
+    )
+    slices = _split_page(page, 20)
+    assert len(slices) >= 2
+    assert all(slice_page.image == b"\x89PNG" for slice_page in slices)

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel
 
 from openextract import Citation
 from openextract._parse import (
+    DEFAULT_RENDER_MAX_EDGE,
     ParsedDocument,
     ParsedPage,
     ParsedSpan,
@@ -24,6 +25,7 @@ from openextract._parse import (
     _flush_word,
     _ground_one,
     _iter_field_values,
+    _luma_pixels,
     _normalized_coco,
     _page_size,
     _page_text,
@@ -31,6 +33,7 @@ from openextract._parse import (
     _parse_pdf_page,
     _pdf_box_to_coco,
     _render_page_png,
+    _render_scale,
     _split_page,
     _union_coco,
     _union_pdf_boxes,
@@ -543,6 +546,7 @@ def test_empty_text_pdf_renders_page_images_not_file_upload():
     assert not parsed.has_text()
     assert parsed.has_images()
     assert all(page.image and page.image.startswith(b"\x89PNG") for page in parsed.pages)
+    assert all(page.image and len(page.image) < 20_000 for page in parsed.pages)
     inputs, got = maybe_parsed_inputs(data, "application/pdf", parse=True)
     assert got is parsed or (got is not None and got.has_images())
     assert inputs is not None
@@ -577,6 +581,12 @@ def test_render_and_png_helpers(monkeypatch):
     assert _channels_for_mode("BGR") == 3
     assert _channels_for_mode("BGRA") == 4
     assert _channels_for_mode("nope") == 0
+    assert _render_scale(3300, 2550) == pytest.approx(DEFAULT_RENDER_MAX_EDGE / 3300)
+    assert _render_scale(100, 80) == 1.0
+    assert _render_scale(0, 0) == 1.0
+    assert _luma_pixels(b"\x80", 1, 1, 1) == (b"\x80", 1)
+    assert _luma_pixels(b"\xff\xff\xff", 1, 1, 3)[1] == 1
+    assert _luma_pixels(b"\x10\x20\x30\x40", 1, 1, 4)[1] == 1
     png = _encode_png(1, 1, b"\xff\x00\x00", 3)
     assert png.startswith(b"\x89PNG")
     assert _render_page_png(SimpleNamespace()) is None
@@ -634,6 +644,18 @@ def test_render_and_png_helpers(monkeypatch):
 
     assert _render_page_png(_Page()).startswith(b"\x89PNG")
     assert bitmap.closed is True
+
+    class _SizedPage:
+        def get_size(self):
+            return 2550.0, 3300.0
+
+        def render(self, scale=1, **_kwargs):
+            assert scale == pytest.approx(DEFAULT_RENDER_MAX_EDGE / 3300)
+            return SimpleNamespace(
+                width=1, height=1, mode="RGB", n_channels=3, stride=3, buffer=b"\x10\x20\x30"
+            )
+
+    assert _render_page_png(_SizedPage()).startswith(b"\x89PNG")
 
 
 def test_maybe_parsed_inputs_headers_when_scan_has_no_image(monkeypatch):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the 6-doc GLM-5.3-flash ExtractBench smoke so it can finish: multi-page docs dying at a 240s wrap, Bianco uploading the original scanned PDF then token-limiting on huge PNGs, Veralto/long killed by ExtractBench’s 1800s × 3 file cap, pueblo dying at a sharp 720s pool wait (~14s after a 706s success), and long hanging in executor shutdown until the 96-window 5760s file cap with no result.json.

Do not merge until Cole smokes this locally. No live ExtractBench/OpenRouter was run in CI/agent.

## Changes

- ExtractBench window-pool wait is `timeout × (ceil(windows / concurrency) + 1)` so GLM variance of tens of seconds does not kill a finishing extract. Pueblo 11 windows: **960s** (was 720s; last success 705.8s). Long 66: **4320s** (was 4080s; leftover finished 2885s).
- After a pool timeout, the executor shuts down with `wait=False`. Previously `with ThreadPoolExecutor` waited on cancelled workers, so long sat until the registered 96-window file cap (5760s) with no result.json.
- ExtractBench **per-file** timeout is `max(1800, pool wait for a 96-window long doc)` and `timeout_retries=0`. No 3×1800s.
- Empty-text / scanned PDFs are rasterized to compact grayscale page PNGs (long edge ≤ 768px) and sent as `image/png`. Original PDF is never uploaded. Boxes stay parser-backed.
- OpenRouter usage copies provider `prompt_tokens` / `completion_tokens` when pydantic-ai leaves zeros. Counts are never invented.
- Tests for timeout budget, pool slack, file-timeout vs pool, cancelled-worker return, scanned path, and usage. CHANGELOG Unreleased only.

## Testing

- `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check` — green
- `uv run pytest -n auto --cov=openextract --cov-fail-under=100` — 785 passed, 5 skipped, 100% coverage
- Did **not** run live ExtractBench / OpenRouter (per request)

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2477cd3a-4401-4781-b6ab-2c3e7d17f899?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2477cd3a-4401-4781-b6ab-2c3e7d17f899&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

