### PR TITLE
Merge leftover windows on pool timeout and raise output retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,14 @@ timing when that is known.
   long-doc window count, and timeout retries are
   disabled. Veralto (41) and long (66) are not killed at 1800s × 3.
 - ExtractBench window-pool wait is
-  ``timeout × (ceil(windows / concurrency) + 1)``, not a sharp
-  ``timeout × batches`` wrap. Pueblo's ~706s 11-window run is not killed at
-  720s; a pool timeout returns immediately instead of waiting on cancelled
-  workers until the 96-window file cap (long / no result.json).
-  Window attempts are still not retried.
+  ``timeout × (ceil(windows / concurrency) + 2)``, not
+  ``timeout × (batches + 1)``. Pueblo's 11-window run is not killed at
+  960s. A pool timeout merges finished windows (and in-flight ones that
+  complete quickly) instead of discarding them, then returns immediately
+  instead of waiting on cancelled workers. Hung windows are still not
+  retried; empty-tool-call / output-retry failures are retried at the
+  window (pydantic-ai ``output_retries=3``, plus one extra attempt) so
+  Veralto is not killed by a 1-retry cap.
 - Empty-text / scanned PDFs (Bianco) are rendered to compact grayscale page
   images (long edge ≤ 768px) locally and never uploaded for OpenRouter
   document-parse (400 rate-limit). Boxes stay parser-backed; none are

--- a/README.md
+++ b/README.md
@@ -738,7 +738,8 @@ with any model:
 uv run python scripts/extractbench.py --model openai:gpt-5 --test
 ```
 
-See [docs/extractbench.md](docs/extractbench.md).
+See [docs/extractbench.md](docs/extractbench.md). Local 6-doc GLM-5.3-flash
+scores: [docs/extractbench-smokes.md](docs/extractbench-smokes.md).
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor guide.
 

--- a/docs/_includes/sidenav.html
+++ b/docs/_includes/sidenav.html
@@ -9,6 +9,7 @@
   <a href="{{ '/troubleshooting.html' | relative_url }}"{% if url == '/troubleshooting.html' %} class="is-active"{% endif %}>Troubleshooting</a>
   <p>Maintain</p>
   <a href="{{ '/extractbench.html' | relative_url }}"{% if url == '/extractbench.html' %} class="is-active"{% endif %}>ExtractBench</a>
+  <a href="{{ '/extractbench-smokes.html' | relative_url }}"{% if url == '/extractbench-smokes.html' %} class="is-active"{% endif %}>ExtractBench smokes</a>
   <a href="{{ '/live-smoke.html' | relative_url }}"{% if url == '/live-smoke.html' %} class="is-active"{% endif %}>Live smoke</a>
   <a href="{{ '/benchmarking.html' | relative_url }}"{% if url == '/benchmarking.html' %} class="is-active"{% endif %}>Benchmarking</a>
   <a href="{{ '/design/input-size-limits.html' | relative_url }}"{% if url == '/design/input-size-limits.html' %} class="is-active"{% endif %}>Input size limits</a>

--- a/docs/extractbench-smokes.md
+++ b/docs/extractbench-smokes.md
@@ -1,0 +1,64 @@
+---
+layout: page
+title: ExtractBench smoke log
+---
+
+# ExtractBench smoke log
+
+Local 6-document `--test` runs of
+[`scripts/extractbench.py`](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/scripts/extractbench.py)
+on OpenRouter `z-ai/glm-5.3-flash`. Citations on. The full 370-document
+benchmark was not run. PyPI is still `0.12.0`; runner changes are in
+CHANGELOG Unreleased.
+
+How to run: [ExtractBench](extractbench.md).
+
+**Gate (not a leaderboard cut):** 6/6 inference finish **and**
+successful-only page F1 > 0.37. Not met on the latest run.
+
+When usage was non-zero, `cost_usd` used OpenRouter list prices
+$0.075 / $0.25 per 1M input / output tokens.
+
+Scores below are ExtractBench unified **value / page / word** F1.
+Successful-only means failed files are omitted from the average, unless
+a row says otherwise.
+
+## t211 (this PR)
+
+| | |
+| --- | --- |
+| When | 2026-09-01, 7:33–8:38 PM CT (~65 min wall) |
+| Code | `f01fc2f` on this PR |
+| Pipeline | `openextract_glm53flash_t211` |
+| Inference | 6/6 OK |
+| Successful-only unweighted | value 0.7716, page 0.2374, word 0.1945 (5 docs; Veralto grounded empty) |
+| Gate | **not met** (page 0.24 < 0.37) |
+| Usage | non-zero; total `cost_usd` $0.515824 |
+
+| Doc | Value | Page | Word | Cites | Wall | cost_usd | Notes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| Bianco | 0.7737 | 0.6133 | 0.0000 | 120 (0 bbox) | 1052s | $0.174865 | Compact grayscale PNG, not PDF upload |
+| W14 | 0.6431 | 0.0102 | 0.0000 | 5 | 20s | $0.003619 | |
+| Goshen | 0.9983 | 0.3510 | 0.5114 | 1411 | 166s | $0.008891 | |
+| Veralto | 0.2727 | 0.0000 | — | 249 | 650s | $0.040680 | `output_retries=3`; grounded empty |
+| pueblo | 0.9982 | 0.2662 | 0.2735 | 5517 | 1278s | $0.041625 | Leftover merge after 1200s pool budget |
+| long | 0.9436 | 0.1838 | 0.1877 | 11768 | 3879s | $0.246144 | Full finish under 4560s pool budget |
+
+## Prior local 6-doc smokes
+
+Same model and cite-on unless a row says otherwise. Successful-only
+averages except where noted. Usage `$0` means recorded token counts
+were zero.
+
+| SHA / PR | Pipeline era | Finish | Value | Page | Word | Wall | Usage | What failed |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| `f5a0fa3` (citations PR) | File-upload | 4/6 | 0.91 | 0.37 | 0.00 | ~15.6 min | $0 | 2× OpenRouter 402 |
+| `c47d2e8` / #207 | Parse-then-extract | 3/6 | 0.87 | 0.26 | 0.28 | ~46 min | $0 | Bianco + Veralto token-limit |
+| `2d83f3e` / #208 | 80k-char windows | 3/6 | 0.86 | 0.13 | 0.17 | ~90 min | $0 | Veralto 1-window token-limit; pueblo/long 3×1800s |
+| `53c1711` / #209 | 1-page windows | 1/6 | 0.65 | 0.01 | 0.00 | ~36 min | | 240s wrap; Bianco 400 file-parse |
+| `09dcb73` (t210) | Scaled timeouts + scan render | 3/6 | 0.85 | 0.21 | 0.22 | ~92 min | yes | Bianco PNG token-limit; Veralto/long 1800s×3 |
+| `e458b2b` (t210b) | File cap ≥ pool; grayscale | 4/6 | 0.68 | 0.08 | 0.11 | ~99 min | yes | Bianco grayscale PNG OK; pueblo 720s pool fail; long 5760s no leftover |
+| `0b798b5` / #210 (t210c) | Pool slack +1; no wait on cancel | 3/6 | 0.78 | 0.10 | 0.13 | ~72 min | yes | pueblo 960s no result; long 4320s no leftover; Veralto `output_retries(1)` fail |
+
+t211 is the first run in this series with 6/6 inference finish.
+Page F1 is still below the 0.37 gate.

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -121,6 +121,10 @@ via `extra_body` as well as `openrouter_usage`).
 `--test` is 6 documents and is the right first run (cents on a hosted API). A
 full run is 370 documents / 4,869 pages and is metered API usage.
 
+Local GLM-5.3-flash `--test` scores are in the
+[ExtractBench smoke log](extractbench-smokes.md). The 370-document run
+has not been run.
+
 Listing this pipeline on the official ExtractBench leaderboard is a later
 change in [run-llama/ExtractBench](https://github.com/run-llama/ExtractBench),
 not this repository.

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -90,15 +90,18 @@ Long documents (and oversized pages) are split into windows under a 12k-characte
 / 1-page budget, extracted with bounded concurrency (`--window-concurrency`, default 4),
 and merged — the whole PDF is not dumped as one prompt. `--timeout` (default 240s)
 is per window; the document wall budget is
-`timeout × (ceil(windows / concurrency) + 1)` so GLM variance of tens of
-seconds (pueblo ~706s vs a sharp 720s) does not kill a finishing extract.
-ExtractBench's per-file timeout is raised to at least that budget for a long
-document (never a hard 1800s below the pool wait) and per-file timeout retries
-are off, so Veralto / long are not run 3×1800s. A pool timeout does not wait
+`timeout × (ceil(windows / concurrency) + 2)` so GLM variance (pueblo
+past 960s) does not kill a finishing extract. When the pool budget
+hits, finished windows and any in-flight that complete quickly are
+merged into a result instead of discarded. ExtractBench's per-file
+timeout is raised to at least that budget for a long document (never a
+hard 1800s below the pool wait) and per-file timeout retries are off,
+so Veralto / long are not run 3×1800s. A pool timeout does not wait
 for cancelled workers (that hang is how long reached the 96-window file cap
-with no result.json). Window calls are a single
-attempt; request timeouts and token-limit errors are not retried at file
-level. Scanned / empty-text PDFs are rendered to compact grayscale page images
+with no result.json). Hung windows are a single attempt; empty-tool-call /
+output-retry failures are retried at the window (`output_retries=3` plus
+one extra attempt). Request timeouts and token-limit errors are not
+retried at file level. Scanned / empty-text PDFs are rendered to compact grayscale page images
 (long edge ≤ 768px) locally and are
 never uploaded for provider document-parse. Citations are collected from
 every window before reduce. When a window

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -49,6 +49,7 @@ from openextract._citations import (
     json_schema_with_citations,
     with_citation_instructions,
 )
+from openextract._errors import _is_output_retry_error
 from openextract._media import _get_media_type
 from openextract._parse import ground_citations, maybe_parsed_inputs, parse_windows
 from openextract._types import _sum_usage
@@ -78,9 +79,15 @@ DEFAULT_WINDOW_CONCURRENCY = 4
 # cap must be ≥ pool budget. 96 windows covers the 6-doc long split with headroom.
 EXTRACTBENCH_FILE_TIMEOUT_FLOOR = 1800.0
 DEFAULT_FILE_TIMEOUT_WINDOWS = 96
-# One extra batch so GLM variance (pueblo 706s vs 720s; W14 298s vs 240s)
-# does not kill a run that is already finishing.
-WINDOW_POOL_SLACK_BATCHES = 1
+# Two extra batches: +1 still killed pueblo at 960s under GLM variance.
+WINDOW_POOL_SLACK_BATCHES = 2
+# After the pool budget, wait briefly for in-flight windows before discarding.
+WINDOW_POOL_LEFTOVER_GRACE = 15.0
+# pydantic-ai default output_retries=1 is the Veralto "exceeded maximum
+# output retries (1)" / empty-tool-call kill. Raise it on window extract.
+WINDOW_OUTPUT_RETRIES = 3
+# Extra Extractor attempt when pydantic-ai still raises after output retries.
+WINDOW_OUTPUT_ATTEMPTS = 2
 _REF_PREFIXES = ("#/$defs/", "#/definitions/")
 
 
@@ -238,6 +245,7 @@ def _build_schema_agent(
             output_type=output_type,
             instructions=instructions,
             model_settings=settings,
+            output_retries=WINDOW_OUTPUT_RETRIES,
         )
     except ImportError as exc:
         if isinstance(model, str):
@@ -344,8 +352,8 @@ def window_pool_timeout(n_windows: int, concurrency: int, timeout: float | None)
 
     ``--timeout`` is per window. Collecting every future with that same value
     kills a 10-page doc at 240s even when each page would finish. Scale by
-    ``ceil(windows / concurrency) + 1`` so pueblo's ~706–800s 11-window run is
-    not killed at exactly 720s when GLM is a few tens of seconds slow.
+    ``ceil(windows / concurrency) + 2`` so pueblo's 11-window run is not
+    killed at 960s when GLM variance exceeds one extra batch.
     """
     if timeout is None:
         return None
@@ -422,27 +430,29 @@ def _extract_parse_windows(
 ) -> tuple[list[dict[str, Any]], Usage]:
     """Extract each parse window and sum usage. Citations are unwrapped later.
 
-    Each window is a single attempt. File-level ExtractBench retries still apply
-    to transient errors; a hung window must not burn the 1800s per-file budget
-    three times (pueblo / long on the 6-doc smoke). The pool wait is the
-    per-window timeout times concurrent batches, plus one batch of slack, not
-    one 240s wrap around the whole document. Do not ``shutdown(wait=True)``
-    after a pool timeout: that is how long sat until the 96-window file cap
-    with no result.json.
+    Hung windows are not retried and must not burn the 1800s per-file budget
+    three times (pueblo / long). Empty-tool-call / output-retry failures are
+    retried at the window, not the file. The pool wait is the per-window
+    timeout times concurrent batches, plus two batches of slack. On timeout,
+    finished windows (and any in-flight that complete quickly) are merged
+    instead of discarded. Do not ``shutdown(wait=True)`` after a pool timeout.
     """
     sources = [_window_source(window) for window in windows]
     workers = max(1, min(window_concurrency, len(sources)))
     once = RetryPolicy(max_retries=0)
 
     def _run(source: bytes, media_type: str) -> tuple[ExtractedDocument, Usage]:
-        agent = _build_schema_agent(model, schema, instructions, timeout=timeout)
-        with Extractor(
-            ExtractedDocument,
-            agent=agent,
-            retry_policy=once,
-            max_input_bytes=max_input_bytes,
-        ) as extractor:
-            return extractor.extract_with_usage(source, media_type=media_type)
+        def _once() -> tuple[ExtractedDocument, Usage]:
+            agent = _build_schema_agent(model, schema, instructions, timeout=timeout)
+            with Extractor(
+                ExtractedDocument,
+                agent=agent,
+                retry_policy=once,
+                max_input_bytes=max_input_bytes,
+            ) as extractor:
+                return extractor.extract_with_usage(source, media_type=media_type)
+
+        return _run_window_with_output_retries(_once)
 
     budget = window_pool_timeout(len(sources), workers, timeout)
     if budget is None:
@@ -454,25 +464,75 @@ def _extract_parse_windows(
     )
 
 
+def window_pool_leftover_grace(budget: float) -> float:
+    """Seconds to wait for in-flight windows after the pool budget expires."""
+    if budget <= 0:
+        return 0.0
+    return min(WINDOW_POOL_LEFTOVER_GRACE, budget * 0.05)
+
+
+def _run_window_with_output_retries(
+    run: Callable[[], tuple[ExtractedDocument, Usage]],
+    *,
+    attempts: int = WINDOW_OUTPUT_ATTEMPTS,
+) -> tuple[ExtractedDocument, Usage]:
+    """Retry a window when pydantic-ai exhausts its output-retry budget."""
+    last: ExtractionError | None = None
+    for attempt in range(attempts):
+        try:
+            return run()
+        except ExtractionError as exc:
+            last = exc
+            if attempt + 1 >= attempts or not _is_output_retry_error(exc):
+                raise
+    raise last  # pragma: no cover
+
+
+def _finished_window_pairs(
+    futures: list,
+) -> list[tuple[ExtractedDocument, Usage]]:
+    """Collect successful window results; skip cancelled and failed futures."""
+    pairs: list[tuple[ExtractedDocument, Usage]] = []
+    for future in futures:
+        if not future.done() or future.cancelled():
+            continue
+        try:
+            pairs.append(future.result())
+        except Exception:
+            continue
+    return pairs
+
+
 def _run_window_pool(
     run: Callable[..., tuple[ExtractedDocument, Usage]],
     sources: list[tuple[bytes, str]],
     workers: int,
     budget: float,
 ) -> list[tuple[ExtractedDocument, Usage]]:
-    """Run windows concurrently and return as soon as the budget expires."""
+    """Run windows concurrently; merge leftovers when the budget expires."""
     pool = ThreadPoolExecutor(max_workers=workers)
     try:
         futures = [pool.submit(run, source, media_type) for source, media_type in sources]
         _done, pending = wait(futures, timeout=budget)
         if pending:
-            for future in futures:
+            _extra, pending = wait(pending, timeout=window_pool_leftover_grace(budget))
+        pairs = _finished_window_pairs(futures)
+        if pending:
+            for future in pending:
                 future.cancel()
+        if pairs:
+            return pairs
+        if pending:
             raise ModelError(
                 f"Parse window timed out after {budget}s",
                 retryable=False,
             )
-        return [future.result() for future in futures]
+        for future in futures:
+            future.result()
+        raise ModelError(
+            f"Parse window timed out after {budget}s",
+            retryable=False,
+        )
     finally:
         pool.shutdown(wait=False, cancel_futures=True)
 
@@ -480,10 +540,13 @@ def _run_window_pool(
 def _extractbench_retryable(exc: ModelError) -> bool:
     """True when ExtractBench should retry the whole file.
 
-    Token-limit and request timeouts are permanent. Retrying them is how
-    pueblo/long spent 1800s three times on the same doomed prompt.
+    Token-limit, request timeouts, and window output-retry failures are
+    permanent at file level. Retrying them is how pueblo/long spent 1800s
+    three times, and how Veralto would re-run 41 pages after one empty call.
     """
-    return exc.retryable and "timeout" not in str(exc).lower()
+    if not exc.retryable or _is_output_retry_error(exc):
+        return False
+    return "timeout" not in str(exc).lower()
 
 
 def _merge_window_payloads(
@@ -814,7 +877,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_CALL_TIMEOUT,
         help=(
             f"per-window model timeout in seconds (default: {int(DEFAULT_CALL_TIMEOUT)}); "
-            "document wall is timeout × (ceil(windows / concurrency) + 1); "
+            "document wall is timeout × (ceil(windows / concurrency) + 2); "
             "ExtractBench per-file timeout is max(1800, that budget for a long doc)"
         ),
     )

--- a/src/openextract/_errors.py
+++ b/src/openextract/_errors.py
@@ -59,6 +59,11 @@ _TOKEN_LIMIT_MARKERS = (
     "prompt is too long",
     "exceeded before any response",
 )
+_OUTPUT_RETRY_TYPES = frozenset({"UnexpectedModelBehavior", "ToolRetryError"})
+_OUTPUT_RETRY_MARKERS = (
+    "output retries",
+    "return text or include your response in a tool call",
+)
 
 # Exact (module, class) signatures for provider/model error bases we classify
 # as ``ModelError``. The classifier checks the exception's existing MRO instead
@@ -234,6 +239,19 @@ def _is_token_limit_error(exc: BaseException) -> bool:
     return any(marker in message for marker in _TOKEN_LIMIT_MARKERS)
 
 
+def _is_output_retry_error(exc: BaseException) -> bool:
+    """True for empty-tool-call / exhausted pydantic-ai output retries."""
+    for current in (exc, exc.__cause__, exc.__context__):
+        if current is None:
+            continue
+        if type(current).__name__ in _OUTPUT_RETRY_TYPES:
+            return True
+        message = str(current).lower()
+        if any(marker in message for marker in _OUTPUT_RETRY_MARKERS):
+            return True
+    return False
+
+
 def _map_exception(exc: BaseException) -> ExtractionError:
     """Translate a low-level exception into the appropriate ExtractionError subclass."""
     if isinstance(exc, httpx.HTTPStatusError):
@@ -248,6 +266,13 @@ def _map_exception(exc: BaseException) -> ExtractionError:
             provider=_model_provider(exc),
             status_code=_model_status_code(exc),
             retryable=False,
+        )
+    if _is_output_retry_error(exc):
+        return ModelError(
+            f"Model output retry exhausted: {exc}",
+            provider=_model_provider(exc),
+            status_code=_model_status_code(exc),
+            retryable=True,
         )
     if _is_model_exception(exc):
         status_code = _model_status_code(exc)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -50,6 +50,7 @@ from openextract._config import (
     _url_fetch_timeout,
 )
 from openextract._errors import (
+    _is_output_retry_error,
     _is_transient_model_exception,
     _map_exception,
     _model_retry_after,
@@ -1312,6 +1313,28 @@ class TestExtract:
         )
         assert isinstance(mapped, ModelError)
         assert mapped.retryable is False
+
+    def test_output_retry_exhausted_is_retryable_model_error(self):
+        from pydantic_ai.exceptions import UnexpectedModelBehavior
+
+        mapped = _map_exception(UnexpectedModelBehavior("Exceeded maximum output retries (1)"))
+        assert isinstance(mapped, ModelError)
+        assert mapped.retryable is True
+        assert "output retry" in str(mapped).lower()
+
+    def test_empty_tool_call_message_is_output_retry_error(self):
+        exc = RuntimeError("Please return text or include your response in a tool call.")
+        assert _is_output_retry_error(exc)
+        assert isinstance(_map_exception(exc), ModelError)
+        wrapped = ExtractionError("Extraction failed: please retry")
+        wrapped.__cause__ = RuntimeError("Exceeded maximum output retries (1)")
+        assert _is_output_retry_error(wrapped)
+
+        class ToolRetryError(Exception):
+            pass
+
+        assert _is_output_retry_error(ToolRetryError("empty call"))
+        assert not _is_output_retry_error(RuntimeError("kaboom"))
 
     def test_model_error_constructor_remains_backwards_compatible(self):
         error = ModelError("flaky")

--- a/tests/test_extractbench.py
+++ b/tests/test_extractbench.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pytest
 from pydantic_ai.models.test import TestModel
 
-from openextract import Citation, ModelError, SchemaValidationError
+from openextract import Citation, ExtractionError, ModelError, SchemaValidationError, Usage
 
 SCRIPTS = Path(__file__).resolve().parents[1] / "scripts"
 if str(SCRIPTS) not in sys.path:
@@ -326,34 +326,46 @@ def test_extractbench_does_not_retry_timeouts():
     assert extractbench._extractbench_retryable(ModelError("rate limited", retryable=True))
     assert not extractbench._extractbench_retryable(ModelError("request timeout", retryable=True))
     assert not extractbench._extractbench_retryable(ModelError("token limit", retryable=False))
+    assert not extractbench._extractbench_retryable(
+        ModelError("Model output retry exhausted: Exceeded maximum output retries (1)")
+    )
 
 
 def test_window_pool_timeout_scales_with_batches():
-    assert extractbench.window_pool_timeout(10, 4, 240.0) == 960.0
-    assert extractbench.window_pool_timeout(11, 4, 240.0) == 960.0
-    assert extractbench.window_pool_timeout(41, 4, 240.0) == 2880.0
-    assert extractbench.window_pool_timeout(66, 4, 240.0) == 4320.0
-    assert extractbench.window_pool_timeout(1, 4, 240.0) == 480.0
+    assert extractbench.window_pool_timeout(10, 4, 240.0) == 1200.0
+    assert extractbench.window_pool_timeout(11, 4, 240.0) == 1200.0
+    assert extractbench.window_pool_timeout(41, 4, 240.0) == 3120.0
+    assert extractbench.window_pool_timeout(66, 4, 240.0) == 4560.0
+    assert extractbench.window_pool_timeout(1, 4, 240.0) == 720.0
     assert extractbench.window_pool_timeout(0, 4, 240.0) == 240.0
     assert extractbench.window_pool_timeout(8, 4, None) is None
 
 
 def test_window_pool_timeout_has_slack_for_pueblo():
-    """Pueblo finished in 705.8s then died at a sharp 720s; 800s must fit."""
+    """Pueblo finished in 705.8s, then died at 720s and 960s; +1 batch was not enough."""
     pueblo = extractbench.window_pool_timeout(11, 4, 240.0)
     assert pueblo is not None
-    assert pueblo >= 800.0
-    assert pueblo > 240.0 * 3
+    assert pueblo > 960.0
+    assert pueblo == 240.0 * (3 + extractbench.WINDOW_POOL_SLACK_BATCHES)
+
+
+def test_window_pool_leftover_grace_scales_with_budget():
+    assert extractbench.window_pool_leftover_grace(0.0) == 0.0
+    assert extractbench.window_pool_leftover_grace(-1.0) == 0.0
+    assert extractbench.window_pool_leftover_grace(0.15) == 0.15 * 0.05
+    assert (
+        extractbench.window_pool_leftover_grace(1200.0) == extractbench.WINDOW_POOL_LEFTOVER_GRACE
+    )
 
 
 def test_extractbench_file_timeout_covers_pool_and_keeps_floor():
     assert extractbench.extractbench_file_timeout(1, 4, 240.0) == 1800.0
     assert extractbench.extractbench_file_timeout(10, 4, 240.0) == 1800.0
-    assert extractbench.extractbench_file_timeout(41, 4, 240.0) == 2880.0
-    assert extractbench.extractbench_file_timeout(66, 4, 240.0) == 4320.0
+    assert extractbench.extractbench_file_timeout(41, 4, 240.0) == 3120.0
+    assert extractbench.extractbench_file_timeout(66, 4, 240.0) == 4560.0
     assert (
         extractbench.extractbench_file_timeout(extractbench.DEFAULT_FILE_TIMEOUT_WINDOWS, 4, 240.0)
-        == 6000.0
+        == 6240.0
     )
     assert extractbench.extractbench_file_timeout(66, 4, None) is None
 
@@ -552,6 +564,166 @@ def test_window_pool_timeout_does_not_wait_on_cancelled_workers(monkeypatch, tmp
             window_concurrency=2,
         )
     assert time.monotonic() - started < 1.0
+
+
+def test_window_pool_timeout_merges_finished_windows(monkeypatch, tmp_path):
+    import time
+
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    pdf = synthetic_pdf(pages=["AAAA page one", "BBBB page two", "CCCC page three"])
+    path = tmp_path / "pueblo.pdf"
+    path.write_bytes(pdf)
+
+    def _mixed(self, source, *, media_type=None):
+        text = source.decode("utf-8", errors="ignore") if isinstance(source, bytes) else ""
+        if "AAAA" in text:
+            return extractbench.ExtractedDocument.model_validate(
+                {"output": {"vendor": "Pueblo"}, "citations": []}
+            ), Usage(1, 1, 2)
+        time.sleep(2.0)
+        raise AssertionError("hung window should be discarded")
+
+    monkeypatch.setattr(extractbench.Extractor, "extract_with_usage", _mixed)
+    started = time.monotonic()
+    data, usage, _citations = extractbench.extract_document_with_citations(
+        path,
+        schema,
+        TestModel(custom_output_args={"output": {"vendor": "Acme"}, "citations": []}),
+        max_retries=0,
+        cite=True,
+        timeout=0.05,
+        window_concurrency=2,
+    )
+    assert time.monotonic() - started < 1.0
+    assert data["vendor"] == "Pueblo"
+    assert usage == Usage(1, 1, 2)
+
+
+def test_window_output_retry_is_retried_at_window(monkeypatch, tmp_path):
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    pdf = synthetic_pdf(pages=["AAAA page one", "BBBB page two"])
+    path = tmp_path / "veralto.pdf"
+    path.write_bytes(pdf)
+    calls = {"n": 0}
+    original = extractbench.Extractor.extract_with_usage
+
+    def _flaky(self, source, *, media_type=None):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ExtractionError("Exceeded maximum output retries (1)")
+        return original(self, source, media_type=media_type)
+
+    monkeypatch.setattr(extractbench.Extractor, "extract_with_usage", _flaky)
+    data, _usage, _citations = extractbench.extract_document_with_citations(
+        path,
+        schema,
+        TestModel(custom_output_args={"output": {"vendor": "Veralto"}, "citations": []}),
+        max_retries=0,
+        cite=True,
+        timeout=2.0,
+        window_concurrency=1,
+    )
+    assert data["vendor"] == "Veralto"
+    assert calls["n"] >= 2
+
+
+def test_window_output_retry_does_not_kill_other_windows(monkeypatch, tmp_path):
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    pdf = synthetic_pdf(pages=["AAAA page one", "BBBB page two"])
+    path = tmp_path / "veralto.pdf"
+    path.write_bytes(pdf)
+    calls = {"n": 0}
+
+    def _one_bad(self, source, *, media_type=None):
+        calls["n"] += 1
+        text = source.decode("utf-8", errors="ignore") if isinstance(source, bytes) else ""
+        if "AAAA" in text:
+            raise ExtractionError("Exceeded maximum output retries (1)")
+        return extractbench.ExtractedDocument.model_validate(
+            {"output": {"vendor": "Veralto"}, "citations": []}
+        ), Usage(2, 1, 3)
+
+    monkeypatch.setattr(extractbench.Extractor, "extract_with_usage", _one_bad)
+    data, usage, _citations = extractbench.extract_document_with_citations(
+        path,
+        schema,
+        TestModel(custom_output_args={"output": {"vendor": "Acme"}, "citations": []}),
+        max_retries=0,
+        cite=True,
+        timeout=2.0,
+        window_concurrency=2,
+    )
+    assert data["vendor"] == "Veralto"
+    assert usage == Usage(2, 1, 3)
+    assert calls["n"] >= 3
+
+
+def test_build_schema_agent_raises_output_retries():
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    agent = extractbench._build_schema_agent(
+        TestModel(custom_output_args={"output": {"vendor": "Acme"}, "citations": []}),
+        extractbench.json_schema_with_citations(extractbench.prepare_schema(schema)),
+        "extract",
+    )
+    assert agent._max_output_retries == extractbench.WINDOW_OUTPUT_RETRIES
+    assert extractbench.WINDOW_OUTPUT_RETRIES > 1
+
+
+def test_window_output_retry_raises_when_nothing_succeeds(monkeypatch, tmp_path):
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    path = tmp_path / "empty.pdf"
+    path.write_bytes(synthetic_pdf(pages=["AAAA page one", "BBBB page two"]))
+
+    def _always_fail(self, source, *, media_type=None):
+        raise ExtractionError("Exceeded maximum output retries (1)")
+
+    monkeypatch.setattr(extractbench.Extractor, "extract_with_usage", _always_fail)
+    with pytest.raises(ExtractionError, match="output retries"):
+        extractbench.extract_document_with_citations(
+            path,
+            schema,
+            TestModel(custom_output_args={"output": {"vendor": "Acme"}, "citations": []}),
+            max_retries=0,
+            cite=True,
+            timeout=2.0,
+            window_concurrency=2,
+        )
+
+
+def test_run_window_with_output_retries_reraises_other_errors():
+    def _boom():
+        raise ModelError("request timeout", retryable=True)
+
+    with pytest.raises(ModelError, match="timeout"):
+        extractbench._run_window_with_output_retries(_boom, attempts=2)
 
 
 def test_merge_window_payloads_keeps_later_citations():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Last local 6-doc GLM smoke on `0b798b5` was 3/6. Pueblo (11 windows) died at the 960s pool budget with no `result.json`. Long (66 windows) died at 4320s and, after #210 `shutdown(wait=False)`, discarded in-flight windows instead of leaving a leftover like the 2885s / value 0.93 attempt. Veralto died on pydantic-ai `Exceeded maximum output retries (1)` / empty tool call.

This PR makes those three docs able to produce a result. **Local t211 smoke on `f01fc2f`:** 6/6 inference OK, successful-only unweighted value 0.7716 / page 0.2374 / word 0.1945. Gate (6/6 and page F1 > 0.37) **not met**. Scores are in `docs/extractbench-smokes.md`. No live OpenRouter from CI. No version bump / PyPI.

## Changes

- Window-pool timeout **merges finished windows** (and any in-flight that complete during a short grace) instead of raising with empty output. Pueblo leftover-merged after 1200s on t211; long finished in 3879s under 4560s.
- Pool slack is **`timeout × (batches + 2)`**, not `+ 1`. Pueblo 11/4/240 is **1200s**, not 960s. File cap stays `max(1800, pool wait)` with `timeout_retries=0`.
- Window extract sets pydantic-ai **`output_retries=3`** plus one extra window attempt on empty-tool-call / output-retry failures. Veralto finished (value 0.2727, grounded empty).
- `UnexpectedModelBehavior` / `ToolRetryError` map to a retryable `ModelError` at the window only.
- Local GLM-5.3-flash 6-doc `--test` series logged in [docs/extractbench-smokes.md](docs/extractbench-smokes.md). 370 was not run. CHANGELOG Unreleased; PyPI still 0.12.0.

## Testing

- Offline: leftover merge on timeout, pool slack (`> 960` for pueblo), output-retry retry, and “one bad window does not kill the rest”.
- `uv run pytest`: 794 passed, 100% coverage; ruff/ty green.
- Local t211 6-doc smoke on `f01fc2f` (cite-on, OpenRouter GLM-5.3-flash): 6/6 finish, page F1 0.24 < 0.37 gate.

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-034a6f49-a19f-4c32-90bc-8bdca51f6f3b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-034a6f49-a19f-4c32-90bc-8bdca51f6f3b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

