### PR TITLE
chore: fix embargo bump push and refresh ExtractBench smoke doc

### DIFF
--- a/.github/workflows/embargo-bump.yml
+++ b/.github/workflows/embargo-bump.yml
@@ -70,7 +70,8 @@ jobs:
           git checkout -B "$BRANCH"
           git add pyproject.toml uv.lock
           git commit -m "$TITLE"
-          git push --force-with-lease origin "$BRANCH"
+          # Checkout has only main, so lease has no expected remote tip; this branch is workflow-owned.
+          git push --force origin "$BRANCH"
           if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
             gh pr edit "$BRANCH" --title "$TITLE" --body "Daily rolling 24h supply-chain embargo bump. Refuses any package version published after \`${NEW_CUTOFF}\`."
           else

--- a/docs/extractbench-smokes.md
+++ b/docs/extractbench-smokes.md
@@ -8,8 +8,8 @@ title: ExtractBench smoke log
 Local 6-document `--test` runs of
 [`scripts/extractbench.py`](https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/scripts/extractbench.py)
 on OpenRouter `z-ai/glm-5.3-flash`. Citations on. The full 370-document
-benchmark was not run. PyPI is still `0.12.0`; runner changes are in
-CHANGELOG Unreleased.
+benchmark was not run. PyPI / package is `0.13.0`; runner/parse-then-extract
+changes are in CHANGELOG `[0.13.0]`.
 
 How to run: [ExtractBench](extractbench.md).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two small post-0.13.0 cleanups. No version bump, no secrets.

## Changes

- Daily `embargo-bump.yml` now `git push --force`s `chore/embargo-bump`. Checkout only has `main`, so `--force-with-lease` had a stale expected tip and the bot-owned branch was rejected.
- `docs/extractbench-smokes.md` intro now says PyPI / package is `0.13.0` and runner/parse-then-extract changes shipped in CHANGELOG `[0.13.0]`. Smoke table and “gate not met” are unchanged.

## Testing

YAML + markdown only. No pytest/ruff impact.

## Checklist

- [x] Documentation updated
- [x] No package version change
- [x] No secrets / OpenRouter keys touched

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8a9fe3ed-6e49-46d6-9e43-837aca3198c9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8a9fe3ed-6e49-46d6-9e43-837aca3198c9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

