### PR TITLE
chore: soft-fail embargo PR create when Actions lacks permission

### DIFF
--- a/.github/workflows/embargo-bump.yml
+++ b/.github/workflows/embargo-bump.yml
@@ -72,8 +72,11 @@ jobs:
           git commit -m "$TITLE"
           # Checkout has only main, so lease has no expected remote tip; this branch is workflow-owned.
           git push --force origin "$BRANCH"
+          # Org settings can deny Actions create-PR even after a successful push.
           if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
-            gh pr edit "$BRANCH" --title "$TITLE" --body "Daily rolling 24h supply-chain embargo bump. Refuses any package version published after \`${NEW_CUTOFF}\`."
-          else
-            gh pr create --head "$BRANCH" --base main --title "$TITLE" --body "Daily rolling 24h supply-chain embargo bump. Refuses any package version published after \`${NEW_CUTOFF}\`."
+            gh pr edit "$BRANCH" --title "$TITLE" --body "Daily rolling 24h supply-chain embargo bump. Refuses any package version published after \`${NEW_CUTOFF}\`." || true
+          elif ! gh pr create --head "$BRANCH" --base main --title "$TITLE" --body "Daily rolling 24h supply-chain embargo bump. Refuses any package version published after \`${NEW_CUTOFF}\`."; then
+            echo "Could not create embargo PR (GitHub Actions is not permitted to create pull requests)."
+            echo "Open one from: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/main...chore/embargo-bump?expand=1"
+            exit 0
           fi


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The org disables Actions from creating or approving pull requests (`GitHub Actions is not permitted to create or approve pull requests`). The daily embargo job already force-pushes `chore/embargo-bump` successfully, then fails on `gh pr create` and marks the whole run red.

This keeps push failures fatal and treats PR view/edit/create as best-effort after a successful push. On create failure the job prints the compare URL and exits 0:

https://github.com/Mellow-Artificial-Intelligence/openextract/compare/main...chore/embargo-bump?expand=1

Package version is unchanged.

## Changes

- Soft-fail `gh pr edit` (`|| true`) when an embargo PR already exists
- Soft-fail `gh pr create` with a compare-URL message and `exit 0`
- Leave `set -euo pipefail` in place so `git push --force` still fails the job

## Testing

- Inspected the Open-or-update-PR script: push stays under `set -e`; PR commands no longer fail the step
- YAML-only change; no package version bump, no pytest/ruff run required

## Checklist

- [x] Documentation updated (if applicable) — N/A
- [x] No package version bump
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19e90e8d-e131-4afb-8c3a-565135f9b773?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19e90e8d-e131-4afb-8c3a-565135f9b773&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

