### PR TITLE
fix(deps): bump pyasn1 to 0.6.4 for CVE-2026-59884

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ timing when that is known.
 - ExtractBench per-SHA smoke lab log (`docs/extractbench-smokes.md`). Latest
   6-doc smoke status now lives in `docs/extractbench.md`.
 
+### Security
+- Bump locked `pyasn1` from 0.6.3 to 0.6.4 to address CVE-2026-59884
+  (unbounded BER tag parsing / DoS). (#217)
+
 ## [0.13.0] - 2026-09-04
 
 ### Changed

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "2026-05-15T00:00:00Z"
+exclude-newer = "2026-09-05T00:00:00Z"
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1589,11 +1589,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump locked `pyasn1` from 0.6.3 to 0.6.4 to fix CVE-2026-59884 (unbounded BER tag parsing / DoS). No public API or package version change.

Closes #217.

## Changes

- Confirmed the lock path with `uv tree --invert --package pyasn1`: `openextract` google / `all` extras and the `dev` group → `pydantic-ai-slim[google]` → `google-genai` → `google-auth` → `pyasn1-modules` → `pyasn1` 0.6.3.
- Refreshed the lock with `uv lock --upgrade-package pyasn1` (hashes from PyPI, not hand-edited). `pyasn1` 0.6.4 was published 2026-07-09, inside the current `exclude-newer` embargo (`2026-09-05`).
- `uv.lock` `[options].exclude-newer` now matches `pyproject.toml` (`2026-09-05T00:00:00Z`; it had been stale at `2026-05-15`). No other packages moved.
- Changelog Unreleased **Security** note for the bump / CVE / #217.
- Left `openextract` at 0.13.0. No extra constraint in `pyproject.toml` — the lock refresh alone landed 0.6.4.

## Testing

- [x] Tests pass locally (`uv run pytest`) — 794 passed, 5 skipped, 100% coverage
- [x] Linting passes (`uv run ruff check .`) — also `ruff format --check` and `ty check`
- [x] Documentation updated (changelog)

Installed lock resolves `pyasn1==0.6.4`. Wheel/sdist hashes match PyPI 0.6.4.

## Reviewer notes

Mechanical lockfile + changelog only. Review `uv.lock` `pyasn1` 0.6.4 hashes against PyPI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d4f38277-e15c-45bb-b55e-82941cb72b16?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d4f38277-e15c-45bb-b55e-82941cb72b16&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

