### PR TITLE
release: 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ timing when that is known.
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-09-11
+
 ### Fixed
 - ExtractBench page/word grounding: one-page windows remap model `page=1` /
   missing pages onto the document page the prompt actually contained, and
@@ -337,7 +339,8 @@ timing when that is known.
 ## [0.1.1] - 2025-09-10
 - Merge pull request #12 from Mellow-Artificial-Intelligence/new-release.
 
-[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.11.0...v0.12.0
 [0.11.0]: https://github.com/Mellow-Artificial-Intelligence/openextract/compare/v0.10.0...v0.11.0

--- a/docs/index.html
+++ b/docs/index.html
@@ -281,10 +281,10 @@ title: openextract
           <div class="flex items-baseline justify-between mb-8 sm:mb-10 flex-wrap gap-3">
             <div>
               <p class="font-mono text-[11px] text-black/40 uppercase tracking-wider mb-2">What&rsquo;s new</p>
-              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">In v0.13.0</h2>
-              <p class="text-sm text-black/40 mt-2">The latest PyPI release: <span class="font-mono">v0.13.0</span>.</p>
+              <h2 class="text-2xl sm:text-3xl font-bold text-black/90">In v0.13.1</h2>
+              <p class="text-sm text-black/40 mt-2">The latest PyPI release: <span class="font-mono">v0.13.1</span>.</p>
             </div>
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#0130---2026-09-04" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#0131---2026-09-11" class="font-mono text-xs text-black/40 hover:text-black/90 transition-colors inline-flex items-center gap-1.5">
               Full changelog <i data-lucide="arrow-up-right" class="w-3 h-3"></i>
             </a>
           </div>
@@ -343,9 +343,9 @@ title: openextract
           </div>
 
           <p class="font-mono text-xs text-black/40">
-            Also in v0.13.0: more reliable OpenRouter usage capture, ExtractBench window-pool slack and leftover-window merge on pool timeout.
-            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#0120---2026-08-31" class="hover:text-black/90 transition-colors">v0.12.0</a>
-            shipped opt-in field citations.
+            Also in v0.13.1: ExtractBench page/word grounding (page remap, value-backfill, numeric/punct boxes; boxes never invented), locked <code>pyasn1</code> 0.6.4 (CVE-2026-59884), and ExtractBench smoke status folded into <code>extractbench.md</code>.
+            <a href="https://github.com/Mellow-Artificial-Intelligence/openextract/blob/main/CHANGELOG.md#0130---2026-09-04" class="hover:text-black/90 transition-colors">v0.13.0</a>
+            shipped more reliable OpenRouter usage capture and ExtractBench window-pool slack.
           </p>
         </div>
       </section>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openextract"
-version = "0.13.0"
+version = "0.13.1"
 description = "Extract structured data from documents, images, audio, and video using LLMs"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1238,7 +1238,7 @@ wheels = [
 
 [[package]]
 name = "openextract"
-version = "0.13.0"
+version = "0.13.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cut **0.13.1** from current main (includes #220 ExtractBench page/word grounding). Patch release: grounding citation fixes, security lock bump, and ExtractBench docs cleanup. No new features.

Merging to `main` with green CI triggers the Release workflow, which publishes `openextract 0.13.1` to PyPI (Trusted Publishing) and creates the `v0.13.1` GitHub release. No tag is created in this PR.

## Changes

- Rebased onto current `main` so the branch includes #220
- `pyproject.toml` / `uv.lock`: version `0.13.0` → `0.13.1` (`uv.lock` stores the editable package version)
- `CHANGELOG.md`: promote `[Unreleased]` into `## [0.13.1] - 2026-09-11` (America/Chicago); leave an empty Unreleased section
  - **Fixed:** ExtractBench page/word grounding (one-page window page remap, value-backfill when quote/page miss, parser boxes for numeric/punct variants, rebind dropped array indexes). Boxes never invented. (#220)
  - **Removed:** `docs/extractbench-smokes.md` folded into `docs/extractbench.md`
  - **Security:** locked `pyasn1` 0.6.3 → 0.6.4 (CVE-2026-59884) (#217)
- `docs/index.html`: point what's-new at v0.13.1, including the grounding Fixed notes

## Testing

- Local maintainer checks from `CONTRIBUTING.md`: ruff, ty, pytest **803 passed / 5 skipped / 100% coverage**
- CI on this PR is green

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9d9d9d3a-6a0a-4c91-a537-827be5c95c71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9d9d9d3a-6a0a-4c91-a537-827be5c95c71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

