### PR TITLE
fix: improve ExtractBench page/word grounding citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ timing when that is known.
 
 ## [Unreleased]
 
+### Fixed
+- ExtractBench page/word grounding: one-page windows remap model `page=1` /
+  missing pages onto the document page the prompt actually contained, and
+  citation grounding locates evidence from the extracted field value when the
+  quote is paraphrased or the hinted page is wrong. Parser boxes now match
+  numeric/punctuation variants (`$1,234.00` vs `1234`) and prefer the value
+  span. Model field paths that drop array indexes (`qty` → `lines[0].qty`) are
+  rebound onto the extracted output. Boxes are still never invented.
+
 ### Removed
 - ExtractBench per-SHA smoke lab log (`docs/extractbench-smokes.md`). Latest
   6-doc smoke status now lives in `docs/extractbench.md`.

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -104,8 +104,10 @@ one extra attempt). Request timeouts and token-limit errors are not
 retried at file level. Scanned / empty-text PDFs are rendered to compact grayscale page images
 (long edge ≤ 768px) locally and are
 never uploaded for provider document-parse. Citations are collected from
-every window before reduce. When a window
-returns values but no cites, pages are backfilled from the local parse
+every window before reduce. One-page windows remap model `page=1` / missing
+pages onto the document page in that window. When a window
+returns values but no cites — or a cite whose quote is paraphrased — pages
+are located from the extracted values in the local parse
 (including numeric display variants). Boxes are never invented and are never
 taken from the model: if a parser span matches the quote (exact, then simple
 fuzzy), a normalized COCO `[x, y, width, height]` in `[0, 1]` is attached; if
@@ -126,8 +128,10 @@ full run is 370 documents / 4,869 pages and is metered API usage.
 Local 6-document `--test` on OpenRouter `z-ai/glm-5.3-flash` (citations on,
 package `0.13.0`) finished 6/6 inference. Successful-only page F1 was 0.24,
 below the maintainer gate (6/6 finish **and** successful-only page F1 > 0.37).
-The full 370-document run has not been run. Listing this pipeline on the
-official ExtractBench leaderboard is a later change in
+Page and word grounding (window page assignment and parser box attachment) is
+in progress in this repository; that smoke number is from before this work and
+is not a new run. The full 370-document run has not been run. Listing this
+pipeline on the official ExtractBench leaderboard is a later change in
 [run-llama/ExtractBench](https://github.com/run-llama/ExtractBench), not this
 repository.
 

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -51,7 +51,12 @@ from openextract._citations import (
 )
 from openextract._errors import _is_output_retry_error
 from openextract._media import _get_media_type
-from openextract._parse import ground_citations, maybe_parsed_inputs, parse_windows
+from openextract._parse import (
+    align_citations_to_window,
+    ground_citations,
+    maybe_parsed_inputs,
+    parse_windows,
+)
 from openextract._types import _sum_usage
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -427,7 +432,7 @@ def _extract_parse_windows(
     max_input_bytes: int | None,
     timeout: float | None,
     window_concurrency: int,
-) -> tuple[list[dict[str, Any]], Usage]:
+) -> tuple[list[tuple[dict[str, Any], object]], Usage]:
     """Extract each parse window and sum usage. Citations are unwrapped later.
 
     Hung windows are not retried and must not burn the 1800s per-file budget
@@ -456,11 +461,14 @@ def _extract_parse_windows(
 
     budget = window_pool_timeout(len(sources), workers, timeout)
     if budget is None:
-        pairs = [_run(source, media_type) for source, media_type in sources]
+        pairs = [
+            (*_run(source, media_type), window)
+            for (source, media_type), window in zip(sources, windows, strict=True)
+        ]
     else:
-        pairs = _run_window_pool(_run, sources, workers, budget)
-    return [as_extracted_dict(part) for part, _usage in pairs], _sum_usage(
-        usage for _part, usage in pairs
+        pairs = _run_window_pool(_run, sources, workers, budget, windows)
+    return [(as_extracted_dict(part), window) for part, _usage, window in pairs], _sum_usage(
+        usage for _part, usage, _window in pairs
     )
 
 
@@ -490,16 +498,18 @@ def _run_window_with_output_retries(
 
 def _finished_window_pairs(
     futures: list,
-) -> list[tuple[ExtractedDocument, Usage]]:
+    windows: tuple,
+) -> list[tuple[ExtractedDocument, Usage, object]]:
     """Collect successful window results; skip cancelled and failed futures."""
-    pairs: list[tuple[ExtractedDocument, Usage]] = []
-    for future in futures:
+    pairs: list[tuple[ExtractedDocument, Usage, object]] = []
+    for future, window in zip(futures, windows, strict=True):
         if not future.done() or future.cancelled():
             continue
         try:
-            pairs.append(future.result())
+            part, usage = future.result()
         except Exception:
             continue
+        pairs.append((part, usage, window))
     return pairs
 
 
@@ -508,7 +518,8 @@ def _run_window_pool(
     sources: list[tuple[bytes, str]],
     workers: int,
     budget: float,
-) -> list[tuple[ExtractedDocument, Usage]]:
+    windows: tuple,
+) -> list[tuple[ExtractedDocument, Usage, object]]:
     """Run windows concurrently; merge leftovers when the budget expires."""
     pool = ThreadPoolExecutor(max_workers=workers)
     try:
@@ -516,7 +527,7 @@ def _run_window_pool(
         _done, pending = wait(futures, timeout=budget)
         if pending:
             _extra, pending = wait(pending, timeout=window_pool_leftover_grace(budget))
-        pairs = _finished_window_pairs(futures)
+        pairs = _finished_window_pairs(futures, windows)
         if pending:
             for future in pending:
                 future.cancel()
@@ -550,13 +561,18 @@ def _extractbench_retryable(exc: ModelError) -> bool:
 
 
 def _merge_window_payloads(
-    payloads: list[dict[str, Any]], *, cite: bool
+    payloads: list[dict[str, Any] | tuple[dict[str, Any], object]], *, cite: bool
 ) -> tuple[dict[str, Any], tuple[Citation, ...]]:
     """Reduce window extractions and keep every window's citations."""
     data_parts: list[ExtractedDocument] = []
     citations: list[Citation] = []
     for payload in payloads:
+        window = None
+        if isinstance(payload, tuple):
+            payload, window = payload
         data, cites = _unwrap_cited_document(payload, cite=cite)
+        if cite and window is not None:
+            cites = align_citations_to_window(cites, window)
         data_parts.append(ExtractedDocument.model_validate(data))
         citations.extend(cites)
     merged = as_extracted_dict(reduce_outputs(data_parts)) if data_parts else {}

--- a/src/openextract/_citations.py
+++ b/src/openextract/_citations.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 from pydantic import BaseModel, Field, create_model
 
-from ._parse import ParsedDocument, ground_citations
+from ._parse import ParsedDocument, align_citations_to_window, ground_citations
 from ._types import Citation, T
 
 _MAX_QUOTE = 2000
@@ -108,19 +108,24 @@ def split_cited_output(
     *,
     cite: bool,
     parsed: ParsedDocument | None = None,
+    window: ParsedDocument | None = None,
 ) -> tuple[T, tuple[Citation, ...]]:
     """Unwrap a cited model payload into ``(schema instance, citations)``.
 
     When ``cite`` is false the raw output is returned unchanged and citations
     are empty, matching the default extract path. When a local parse is
     provided, pages are stamped from it and boxes come only from parser spans.
+    ``window`` remaps page=1 / missing pages onto the single page the model saw.
     """
     if not cite:
         return cast(T, raw), ()
     wrapper_type = cited_output_schema(schema)
     wrapper = cast(Any, raw if isinstance(raw, wrapper_type) else wrapper_type.model_validate(raw))
     output = cast(T, wrapper.output)
-    citations = ground_citations(citations_from_payload(wrapper.citations), parsed, output)
+    citations = citations_from_payload(wrapper.citations)
+    if window is not None:
+        citations = align_citations_to_window(citations, window)
+    citations = ground_citations(citations, parsed, output)
     return output, citations
 
 

--- a/src/openextract/_parse.py
+++ b/src/openextract/_parse.py
@@ -218,6 +218,50 @@ def parsed_window_inputs(
     return [parsed_run_inputs(window) for window in windows]
 
 
+def parsed_window_pairs(
+    parsed: ParsedDocument | None,
+    fallback_inputs: list,
+    *,
+    max_chars: int | None = None,
+    max_pages: int | None = None,
+) -> list[tuple[list, ParsedDocument | None]]:
+    """Pair each window's model inputs with the parse slice the model saw."""
+    inputs = parsed_window_inputs(parsed, fallback_inputs, max_chars=max_chars, max_pages=max_pages)
+    if parsed is None or not parsed.pages:
+        return [(item, None) for item in inputs]
+    windows = parse_windows(parsed, max_chars=max_chars, max_pages=max_pages)
+    if len(inputs) != len(windows):
+        return [(item, parsed) for item in inputs]
+    return list(zip(inputs, windows, strict=True))
+
+
+def align_citations_to_window(
+    citations: tuple[Citation, ...],
+    window: ParsedDocument | None,
+) -> tuple[Citation, ...]:
+    """Map model page numbers onto the single document page a window contained.
+
+    ExtractBench uses one page per window. Models often emit ``page=1`` (or omit
+    page) even when the prompt is marked ``--- Page N ---``. Multi-page windows
+    are left unchanged so document-level pages stay intact.
+    """
+    if window is None or not window.pages:
+        return citations
+    window_pages = {page.page for page in window.pages}
+    if len(window_pages) != 1:
+        return citations
+    only = next(iter(window_pages))
+    return tuple(
+        Citation(
+            field=item.field,
+            quote=item.quote,
+            page=only if item.page is None or item.page not in window_pages else item.page,
+            bbox=item.bbox,
+        )
+        for item in citations
+    )
+
+
 def maybe_parsed_inputs(
     file_bytes: bytes,
     file_type: str,
@@ -252,16 +296,25 @@ def ground_citations(
 
     Model-supplied boxes are ignored. A citation with a valid page is kept even
     when the quote is short. Unmatched spans omit ``bbox`` rather than guessing.
+    When the model quotes a paraphrase or the wrong page, the extracted field
+    value is used to locate evidence already in the parse.
     """
     if parsed is None:
         return tuple(
             Citation(field=item.field, quote=item.quote, page=item.page, bbox=None)
             for item in citations
         )
-    grounded = [_ground_one(item, parsed) for item in citations]
+    values = dict(_iter_field_values(output))
+    grounded: list[Citation] = []
+    for item in citations:
+        field = _rebind_field(item.field, item.quote, values)
+        if field != item.field:
+            item = Citation(field=field, quote=item.quote, page=item.page, bbox=item.bbox)
+        grounded.append(_ground_one(item, parsed, values.get(field)))
+    grounded = _dedupe_citations(grounded)
     seen = {item.field for item in grounded}
     extras: list[Citation] = []
-    for field, value in _iter_field_values(output):
+    for field, value in values.items():
         if field in seen:
             continue
         extra = _citation_from_value(field, value, parsed)
@@ -554,8 +607,14 @@ def _normalized_coco(
     return (x, y, width, height)
 
 
-def _ground_one(citation: Citation, parsed: ParsedDocument) -> Citation:
-    page, bbox = find_span(parsed, citation.quote, hinted_page=citation.page)
+def _ground_one(
+    citation: Citation,
+    parsed: ParsedDocument,
+    field_value: str | None = None,
+) -> Citation:
+    page, bbox = find_span(
+        parsed, citation.quote, field_value=field_value, hinted_page=citation.page
+    )
     if page is None:
         page = citation.page if citation.page is not None and citation.page >= 1 else None
     return Citation(field=citation.field, quote=citation.quote, page=page, bbox=bbox)
@@ -569,15 +628,78 @@ def find_span(
     hinted_page: int | None = None,
 ) -> tuple[int | None, tuple[float, float, float, float] | None]:
     """Locate ``quote`` (then ``field_value``) on the parse: exact, then fuzzy."""
-    needles = [text for text in (quote, field_value) if text and str(text).strip()]
-    if not needles:
+    quote_needles = _needles_of(quote)
+    value_needles = _value_needles(field_value) if field_value else ()
+    if not quote_needles and not value_needles:
         return _valid_page(hinted_page), None
+    hint = _valid_page(hinted_page)
+    quote_hit = _first_hit(parsed, quote_needles, hinted_page, fuzzy=False)
+    value_hit = _first_hit(parsed, value_needles, hinted_page, fuzzy=False)
+    chosen = _choose_page(quote_hit, value_hit, hint)
+    if chosen is None:
+        quote_hit = _first_hit(parsed, quote_needles, hinted_page, fuzzy=True)
+        value_hit = _first_hit(parsed, value_needles, hinted_page, fuzzy=True)
+        chosen = _choose_page(quote_hit, value_hit, hint)
+    if chosen is None:
+        return hint, None
+    bbox = _bbox_on_page(parsed, chosen, value_needles) or _bbox_on_page(
+        parsed, chosen, quote_needles
+    )
+    return chosen, bbox
+
+
+def _needles_of(text: str | None) -> tuple[str, ...]:
+    if text is None:
+        return ()
+    stripped = str(text).strip()
+    return (stripped,) if stripped else ()
+
+
+def _first_hit(
+    parsed: ParsedDocument,
+    needles: tuple[str, ...],
+    hinted_page: int | None,
+    *,
+    fuzzy: bool,
+) -> tuple[int, tuple[float, float, float, float] | None] | None:
+    if not needles:
+        return None
     pages = _pages_for_hint(parsed, hinted_page)
     for needle in needles:
         for page in pages:
-            if _haystack_has(page.text, needle):
+            if _haystack_has(page.text, needle, fuzzy=fuzzy):
                 return page.page, _bbox_for_quote(page, needle)
-    return _valid_page(hinted_page), None
+    return None
+
+
+def _choose_page(
+    quote_hit: tuple[int, tuple[float, float, float, float] | None] | None,
+    value_hit: tuple[int, tuple[float, float, float, float] | None] | None,
+    hint: int | None,
+) -> int | None:
+    """Prefer the extracted value when a short/common quote hits the hinted page."""
+    quote_page = quote_hit[0] if quote_hit is not None else None
+    value_page = value_hit[0] if value_hit is not None else None
+    if value_page is not None and quote_page is not None:
+        if hint is not None and quote_page == hint and value_page != hint:
+            return value_page
+        return quote_page
+    return quote_page if quote_page is not None else value_page
+
+
+def _bbox_on_page(
+    parsed: ParsedDocument,
+    page_no: int,
+    needles: tuple[str, ...],
+) -> tuple[float, float, float, float] | None:
+    page = next((item for item in parsed.pages if item.page == page_no), None)
+    if page is None:
+        return None
+    for needle in needles:
+        box = _bbox_for_quote(page, needle)
+        if box is not None:
+            return box
+    return None
 
 
 def _pages_for_hint(parsed: ParsedDocument, hinted_page: int | None) -> tuple[ParsedPage, ...]:
@@ -592,11 +714,11 @@ def _valid_page(page: int | None) -> int | None:
     return page if isinstance(page, int) and not isinstance(page, bool) and page >= 1 else None
 
 
-def _haystack_has(haystack: str, needle: str) -> bool:
-    return _find_in_text(haystack, needle) is not None
+def _haystack_has(haystack: str, needle: str, *, fuzzy: bool = True) -> bool:
+    return _find_in_text(haystack, needle, fuzzy=fuzzy) is not None
 
 
-def _find_in_text(haystack: str, needle: str) -> int | None:
+def _find_in_text(haystack: str, needle: str, *, fuzzy: bool = True) -> int | None:
     norm_h = _normalize(haystack)
     norm_n = _normalize(needle)
     if not norm_n:
@@ -604,7 +726,9 @@ def _find_in_text(haystack: str, needle: str) -> int | None:
     index = norm_h.find(norm_n)
     if index >= 0:
         return index
-    if len(norm_n) < 2:
+    if _numeric_in_text(haystack, needle):
+        return 0
+    if not fuzzy or len(norm_n) < 2:
         return None
     window = len(norm_n)
     step = max(1, window // 4)
@@ -617,6 +741,17 @@ def _find_in_text(haystack: str, needle: str) -> int | None:
             best_ratio = ratio
             best_index = start
     return best_index
+
+
+def _numeric_in_text(haystack: str, needle: str) -> bool:
+    want = _try_number(needle)
+    if want is None:
+        return False
+    for token in haystack.split():
+        got = _try_number(token.strip(".;:()[]"))
+        if got is not None and got == want:
+            return True
+    return False
 
 
 def _bbox_for_quote(page: ParsedPage, quote: str) -> tuple[float, float, float, float] | None:
@@ -635,9 +770,9 @@ def _bbox_for_quote(page: ParsedPage, quote: str) -> tuple[float, float, float, 
             if span.bbox is not None:
                 boxes.append(span.bbox)
             joined = " ".join(parts)
-            if joined == needle or needle in joined:
+            if _needle_covers(joined, needle):
                 return _union_coco(boxes)
-            if not (needle.startswith(joined) or joined in needle):
+            if not _needle_can_grow(joined, needle):
                 break
     best_box: tuple[float, float, float, float] | None = None
     best_ratio = _FUZZY_RATIO
@@ -651,6 +786,57 @@ def _bbox_for_quote(page: ParsedPage, quote: str) -> tuple[float, float, float, 
     return best_box
 
 
+def _needle_covers(joined: str, needle: str) -> bool:
+    if not needle:
+        return False
+    if joined == needle or needle in joined:
+        return True
+    if _numbers_match(joined, needle):
+        return True
+    folded_j, folded_n = _fold_alnum(joined), _fold_alnum(needle)
+    if not folded_n:
+        return False
+    if _try_number(joined) is not None or _try_number(needle) is not None:
+        return False
+    return folded_j == folded_n or folded_n in folded_j
+
+
+def _needle_can_grow(joined: str, needle: str) -> bool:
+    if needle.startswith(joined) or joined in needle:
+        return True
+    folded_j, folded_n = _fold_alnum(joined), _fold_alnum(needle)
+    if folded_n and (folded_n.startswith(folded_j) or folded_j in folded_n):
+        return True
+    return _try_number(joined) is not None and _try_number(needle) is not None
+
+
+def _fold_alnum(text: str) -> str:
+    return "".join(ch for ch in text.casefold() if ch.isalnum())
+
+
+def _try_number(text: str) -> float | None:
+    stripped = (
+        text.replace(",", "")
+        .replace("$", "")
+        .replace("£", "")
+        .replace("€", "")
+        .replace("%", "")
+        .strip()
+    )
+    if stripped.startswith("(") and stripped.endswith(")"):
+        stripped = f"-{stripped[1:-1].strip()}"
+    try:
+        number = float(stripped)
+    except ValueError:
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _numbers_match(left: str, right: str) -> bool:
+    left_n, right_n = _try_number(left), _try_number(right)
+    return left_n is not None and right_n is not None and left_n == right_n
+
+
 def _union_coco(
     boxes: list[tuple[float, float, float, float]],
 ) -> tuple[float, float, float, float] | None:
@@ -661,6 +847,73 @@ def _union_coco(
     x1 = max(box[0] + box[2] for box in boxes)
     y1 = max(box[1] + box[3] for box in boxes)
     return _normalized_coco(x0, y0, x1 - x0, y1 - y0)
+
+
+def _rebind_field(field: str, quote: str | None, values: dict[str, str]) -> str:
+    """Map a model field path onto an extracted path when indexes were dropped."""
+    if field in values:
+        return field
+    key = _strip_indexes(field)
+    matches = [
+        path
+        for path in values
+        if (stripped := _strip_indexes(path)) == key or stripped.endswith(f".{key}")
+    ]
+    if len(matches) == 1:
+        return matches[0]
+    quote_n = _normalize(quote) if quote else ""
+    if not quote_n:
+        return field
+    for path in matches:
+        value_n = _normalize(values[path])
+        if value_n and (value_n == quote_n or value_n in quote_n or quote_n in value_n):
+            return path
+    return field
+
+
+def _strip_indexes(field: str) -> str:
+    out: list[str] = []
+    index = 0
+    length = len(field)
+    while index < length:
+        char = field[index]
+        if char == "[":
+            close = index + 1
+            while close < length and field[close].isdigit():
+                close += 1
+            if close < length and field[close] == "]" and close > index + 1:
+                out.append("[]")
+                index = close + 1
+                continue
+        out.append(char)
+        index += 1
+    return "".join(out)
+
+
+def _dedupe_citations(citations: list[Citation]) -> list[Citation]:
+    """Keep one citation per field+page, preferring a parser box."""
+    best: dict[tuple[str, int | None], Citation] = {}
+    order: list[tuple[str, int | None]] = []
+    for item in citations:
+        key = (item.field, item.page)
+        previous = best.get(key)
+        if previous is None:
+            order.append(key)
+            best[key] = item
+            continue
+        best[key] = item if _citation_rank(item) > _citation_rank(previous) else previous
+    return [best[key] for key in order]
+
+
+def _citation_rank(citation: Citation) -> tuple[int, int, int]:
+    area = 0
+    if citation.bbox is not None:
+        area = -int(citation.bbox[2] * citation.bbox[3] * 1_000_000)
+    return (
+        1 if citation.bbox is not None else 0,
+        1 if citation.quote else 0,
+        area,
+    )
 
 
 def _citation_from_value(field: str, value: str, parsed: ParsedDocument) -> Citation | None:

--- a/src/openextract/_windows.py
+++ b/src/openextract/_windows.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Sequence
 
 from ._citations import split_cited_output
-from ._parse import ParsedDocument, ground_citations, parsed_window_inputs
+from ._parse import ParsedDocument, ground_citations, parsed_window_pairs
 from ._reduce import reduce_outputs
 from ._retry import _run_with_retries_async, _run_with_retries_sync
 from ._types import Citation, T, Usage, _sum_usage
@@ -26,17 +26,20 @@ def extract_windows_sync(
     retry_max_backoff: float,
 ) -> tuple[T, Usage, tuple[Citation, ...]]:
     """Extract each parse window (or the one-window fast path) and merge."""
-    windows = parsed_window_inputs(parsed, inputs)
+    windows = parsed_window_pairs(parsed, inputs)
     outputs: list[T] = []
     usages: list[Usage] = []
     citations: list[Citation] = []
-    for window in windows:
+    for window, window_parse in windows:
 
         def _once(
             window: list = window,
+            window_parse: ParsedDocument | None = window_parse,
         ) -> tuple[T, Usage, tuple[Citation, ...]]:
             raw, usage = run(window)
-            output, cites = split_cited_output(raw, schema, cite=cite, parsed=parsed)
+            output, cites = split_cited_output(
+                raw, schema, cite=cite, parsed=parsed, window=window_parse
+            )
             return output, usage, cites
 
         output, usage, cites = _run_with_retries_sync(
@@ -63,17 +66,20 @@ async def extract_windows_async(
     retry_max_backoff: float,
 ) -> tuple[T, Usage, tuple[Citation, ...]]:
     """Async sibling of :func:`extract_windows_sync`."""
-    windows = parsed_window_inputs(parsed, inputs)
+    windows = parsed_window_pairs(parsed, inputs)
     outputs: list[T] = []
     usages: list[Usage] = []
     citations: list[Citation] = []
-    for window in windows:
+    for window, window_parse in windows:
 
         async def _once(
             window: list = window,
+            window_parse: ParsedDocument | None = window_parse,
         ) -> tuple[T, Usage, tuple[Citation, ...]]:
             raw, usage = await run(window)
-            output, cites = split_cited_output(raw, schema, cite=cite, parsed=parsed)
+            output, cites = split_cited_output(
+                raw, schema, cite=cite, parsed=parsed, window=window_parse
+            )
             return output, usage, cites
 
         output, usage, cites = await _run_with_retries_async(

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -179,6 +179,22 @@ class TestSchemaWrap:
         assert output == Person(name="Ada", age=36)
         assert citations[0].field == "name"
 
+    def test_split_aligns_citations_to_one_page_window(self):
+        from openextract._parse import ParsedDocument, ParsedPage
+
+        window = ParsedDocument(pages=(ParsedPage(4, "Ada", 1, 1, ()),))
+        output, citations = split_cited_output(
+            {
+                "output": {"name": "Ada", "age": 36},
+                "citations": [{"field": "name", "quote": "Ada"}],
+            },
+            Person,
+            cite=True,
+            window=window,
+        )
+        assert output == Person(name="Ada", age=36)
+        assert citations[0].page == 4
+
 
 class TestExtractCite:
     def test_default_extract_does_not_wrap_or_add_instructions(self):

--- a/tests/test_extractbench.py
+++ b/tests/test_extractbench.py
@@ -726,6 +726,58 @@ def test_run_window_with_output_retries_reraises_other_errors():
         extractbench._run_window_with_output_retries(_boom, attempts=2)
 
 
+def test_window_page_one_citation_stamps_document_page(tmp_path):
+    from tests.pdf_fixture import synthetic_pdf
+
+    schema = {
+        "type": "object",
+        "properties": {"vendor": {"type": "string"}},
+        "required": ["vendor"],
+    }
+    pdf = synthetic_pdf(pages=["AAAA noise", "Acme Corp"])
+    path = tmp_path / "windowed.pdf"
+    path.write_bytes(pdf)
+    data, _usage, citations = extractbench.extract_document_with_citations(
+        path,
+        schema,
+        TestModel(
+            custom_output_args={
+                "output": {"vendor": "Acme Corp"},
+                "citations": [{"field": "vendor", "quote": "the supplier", "page": 1}],
+            }
+        ),
+        max_retries=0,
+        cite=True,
+    )
+    assert data["vendor"] == "Acme Corp"
+    vendor = next(item for item in citations if item.field == "vendor")
+    assert vendor.page == 2
+    assert vendor.bbox is not None
+    mapped = extractbench.field_citations_for_extractbench(citations)
+    assert mapped[0]["page"] == 2
+    assert mapped[0]["bbox"] == list(vendor.bbox)
+
+
+def test_merge_window_payloads_aligns_single_page_window():
+    from openextract._parse import ParsedDocument, ParsedPage
+
+    window = ParsedDocument(pages=(ParsedPage(2, "Acme Corp", 1, 1, ()),))
+    data, citations = extractbench._merge_window_payloads(
+        [
+            (
+                {
+                    "output": {"vendor": "Acme Corp"},
+                    "citations": [{"field": "vendor", "quote": "Acme Corp", "page": 1}],
+                },
+                window,
+            )
+        ],
+        cite=True,
+    )
+    assert data["vendor"] == "Acme Corp"
+    assert citations[0].page == 2
+
+
 def test_merge_window_payloads_keeps_later_citations():
     data, citations = extractbench._merge_window_payloads(
         [

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -15,6 +15,7 @@ from openextract._parse import (
     ParsedPage,
     ParsedSpan,
     _bbox_for_quote,
+    _bbox_on_page,
     _bitmap_to_png,
     _channels_for_mode,
     _char_box,
@@ -23,23 +24,30 @@ from openextract._parse import (
     _encode_png,
     _find_in_text,
     _flush_word,
+    _fold_alnum,
     _ground_one,
     _iter_field_values,
     _luma_pixels,
+    _needle_covers,
     _normalized_coco,
+    _numeric_in_text,
     _page_size,
     _page_text,
     _pages_prompt_len,
     _parse_pdf_page,
     _pdf_box_to_coco,
+    _rebind_field,
     _render_page_png,
     _render_scale,
     _split_page,
+    _strip_indexes,
+    _try_number,
     _union_coco,
     _union_pdf_boxes,
     _value_needles,
     _walk_fields,
     _word_spans,
+    align_citations_to_window,
     find_span,
     ground_citations,
     maybe_parsed_inputs,
@@ -47,6 +55,7 @@ from openextract._parse import (
     parsed_image_inputs,
     parsed_run_inputs,
     parsed_window_inputs,
+    parsed_window_pairs,
     try_parse_document,
 )
 from tests.pdf_fixture import synthetic_pdf
@@ -111,6 +120,136 @@ def test_grounding_stamps_page_and_backfills_field_value():
     assert fields["total"].bbox == pytest.approx((0.4, 0.1, 0.2, 0.05))
     assert fields["label"].quote == "Total"
     assert fields["label"].bbox == pytest.approx((0.1, 0.1, 0.2, 0.05))
+
+
+def test_grounding_uses_field_value_when_quote_and_page_are_wrong():
+    parsed = ParsedDocument(
+        pages=(
+            _page("Total 99", ParsedSpan("99", 1, (0.1, 0.1, 0.1, 0.05)), page=1),
+            _page(
+                "Acme Corp",
+                ParsedSpan("Acme", 2, (0.2, 0.2, 0.2, 0.05)),
+                ParsedSpan("Corp", 2, (0.4, 0.2, 0.2, 0.05)),
+                page=2,
+            ),
+        )
+    )
+    grounded = ground_citations(
+        (Citation("vendor", "the supplier name", page=1),),
+        parsed,
+        {"vendor": "Acme Corp"},
+    )
+    assert grounded[0].field == "vendor"
+    assert grounded[0].page == 2
+    assert grounded[0].bbox == pytest.approx((0.2, 0.2, 0.4, 0.05))
+
+
+def test_grounding_prefers_value_page_over_common_quote_on_hint():
+    parsed = ParsedDocument(
+        pages=(
+            _page("Total 1", ParsedSpan("Total", 1, (0.1, 0.1, 0.2, 0.05)), page=1),
+            _page(
+                "Total 12.50",
+                ParsedSpan("12.50", 2, (0.4, 0.1, 0.2, 0.05)),
+                page=2,
+            ),
+        )
+    )
+    grounded = ground_citations(
+        (Citation("total", "Total", page=1),),
+        parsed,
+        {"total": "12.50"},
+    )
+    assert grounded[0].page == 2
+    assert grounded[0].bbox == pytest.approx((0.4, 0.1, 0.2, 0.05))
+
+
+def test_numeric_span_attaches_box_for_plain_extracted_number():
+    parsed = ParsedDocument(
+        pages=(
+            _page(
+                "Paid $1,234.00",
+                ParsedSpan("$1,234.00", 1, (0.2, 0.1, 0.3, 0.05)),
+            ),
+        )
+    )
+    grounded = ground_citations(
+        (Citation("amount", "1234", page=1),),
+        parsed,
+        {"amount": 1234},
+    )
+    assert grounded[0].page == 1
+    assert grounded[0].bbox == pytest.approx((0.2, 0.1, 0.3, 0.05))
+
+
+def test_rebind_drops_missing_array_index_and_dedupes_boxes():
+    parsed = ParsedDocument(
+        pages=(
+            _page(
+                "qty 3",
+                ParsedSpan("3", 1, (0.5, 0.1, 0.05, 0.05)),
+            ),
+        )
+    )
+    grounded = ground_citations(
+        (
+            Citation("qty", "3", page=1),
+            Citation("lines[0].qty", "3", page=1, bbox=None),
+        ),
+        parsed,
+        {"lines": [{"qty": 3}]},
+    )
+    assert [item.field for item in grounded] == ["lines[0].qty"]
+    assert grounded[0].bbox == pytest.approx((0.5, 0.1, 0.05, 0.05))
+    duped = ground_citations(
+        (
+            Citation("ghost", "nope", page=1),
+            Citation("ghost", "3", page=1),
+            Citation("ghost", "still-nope", page=1),
+        ),
+        parsed,
+    )
+    ghosts = [item for item in duped if item.field == "ghost"]
+    assert len(ghosts) == 1
+    assert ghosts[0].bbox == pytest.approx((0.5, 0.1, 0.05, 0.05))
+
+
+def test_align_citations_to_window_stamps_single_page():
+    window = ParsedDocument(pages=(_page("Acme Corp", page=5),))
+    citations = (
+        Citation("vendor", "Acme Corp", page=1),
+        Citation("total", "12", page=None),
+        Citation("ok", "x", page=5),
+    )
+    aligned = align_citations_to_window(citations, window)
+    assert aligned[0].page == 5
+    assert aligned[1].page == 5
+    assert aligned[2].page == 5
+    assert align_citations_to_window(citations, None) == citations
+    empty = ParsedDocument(pages=())
+    assert align_citations_to_window(citations, empty) == citations
+    multi = ParsedDocument(pages=(_page("a", page=2), _page("b", page=3)))
+    assert align_citations_to_window(citations, multi) == citations
+
+
+def test_parsed_window_pairs_and_mismatch_fallback(monkeypatch):
+    parsed = ParsedDocument(pages=(_page("hello", page=1),))
+    pairs = parsed_window_pairs(parsed, ["fallback"])
+    assert len(pairs) == 1
+    assert pairs[0][1] is parsed
+    assert parsed_window_pairs(None, ["fallback"]) == [(["fallback"], None)]
+    assert parsed_window_pairs(ParsedDocument(pages=()), ["fallback"]) == [(["fallback"], None)]
+    calls = {"n": 0}
+
+    def _windows(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return (parsed,)
+        return ()
+
+    monkeypatch.setattr("openextract._parse.parse_windows", _windows)
+    mismatched = parsed_window_pairs(parsed, ["fallback"])
+    assert mismatched == [(["fallback"], parsed)]
 
 
 def test_maybe_parsed_inputs_swaps_in_page_text():
@@ -221,6 +360,9 @@ def test_find_span_exact_fuzzy_and_hint():
     assert _find_in_text("abc", "x") is None
     assert _find_in_text("abc", "z") is None
     assert find_span(parsed, "zzz", hinted_page=2) == (2, None)
+    value_page, value_bbox = find_span(parsed, None, field_value="revenue beat")
+    assert value_page == 2
+    assert value_bbox is not None
 
 
 def test_ground_citations_without_parse_drops_model_bbox():
@@ -307,7 +449,8 @@ def test_walk_nested_fields_and_short_quote():
     )
     from_int = ground_citations((), money, {"amount": 1234})
     from_float = ground_citations((), money, {"amount": 1234.0})
-    assert from_int[0].page == 1 and from_int[0].quote == "1,234"
+    assert from_int[0].page == 1
+    assert from_int[0].quote in {"1234", "1,234"}
     assert from_float[0].page == 1
     assert "1,234" in _value_needles("1234.0")
     assert _value_needles("Acme") == ("Acme",)
@@ -333,7 +476,33 @@ def test_walk_nested_fields_and_short_quote():
         ParsedSpan("Acme", 1, (0.2, 0.2, 0.2, 0.1)),
     )
     assert _bbox_for_quote(fuzzy_page, "Acmee") == pytest.approx((0.2, 0.2, 0.2, 0.1))
+    punct = _page(
+        "Acme, Inc.",
+        ParsedSpan("Acme,", 1, (0.1, 0.1, 0.2, 0.05)),
+        ParsedSpan("Inc.", 1, (0.3, 0.1, 0.15, 0.05)),
+    )
+    assert _bbox_for_quote(punct, "Acme Inc") is not None
     assert list(_walk_fields(object(), "x")) == []
+    assert _rebind_field("vendor", None, {"vendor": "Acme"}) == "vendor"
+    assert _rebind_field("qty", "3", {"lines[0].qty": "3", "other": "x"}) == "lines[0].qty"
+    assert _rebind_field("qty", "3", {"lines[0].qty": "1", "lines[1].qty": "3"}) == "lines[1].qty"
+    assert _rebind_field("qty", "zzz", {"lines[0].qty": "1", "lines[1].qty": "2"}) == "qty"
+    assert _rebind_field("qty", None, {"lines[0].qty": "1", "lines[1].qty": "2"}) == "qty"
+    assert _strip_indexes("lines[0].qty") == "lines[].qty"
+    assert _strip_indexes("items[12]") == "items[]"
+    assert _strip_indexes("arr[") == "arr["
+    assert _strip_indexes("arr[x]") == "arr[x]"
+    assert _try_number("(12.5)") == pytest.approx(-12.5)
+    assert _try_number("inf") is None
+    assert _try_number("not-a-number") is None
+    assert _numeric_in_text("Paid $1,234.00", "1234")
+    assert not _numeric_in_text("hello", "1234")
+    assert not _numeric_in_text("1,234", "abc")
+    assert _needle_covers("acme,", "Acme")
+    assert not _needle_covers("acme", "")
+    assert not _needle_covers("$$$", "!!!")
+    assert _fold_alnum("Acme,") == "acme"
+    assert _bbox_on_page(ParsedDocument(pages=(_page("x"),)), 9, ("x",)) is None
 
 
 def test_word_span_space_and_missing_box():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Page-level ExtractBench F1 was ~0.24 (gate >0.37) while value F1 was fine (~0.77), because citations often kept the **wrong page** and **no parser box** even when the local parse had the evidence.

Root cause on the cite=True / parse-then-extract path:

1. **One-page windows.** The default window is a single document page marked `--- Page N ---`. Models (GLM-5.3-flash especially) still emit `page=1` or omit page. Grounding then preferred page 1, so a common quote (`Total`, short numbers) false-matched the hinted page.
2. **Paraphrased quotes blocked value backfill.** `_ground_one` only searched the model quote. If it missed, the model’s (wrong) page was kept and that field was marked “seen”, so the extracted value was never used to locate the span.
3. **Boxes missed numeric/punctuation variants.** `$1,234.00` vs extracted `1234`, or `Acme,` vs `Acme`, did not attach a parser box. Gold word-level boxes are tight value spans, so this killed word F1.
4. **Dropped array indexes.** Cites like `qty` instead of `lines[0].qty` never matched ExtractBench field patterns.

## Changes

- Remap `page=1` / missing pages onto the **single document page** that window actually contained (library windows + ExtractBench merge). Multi-page windows are left unchanged.
- Ground with the **extracted field value** when the quote is paraphrased or the hinted page is a false match. Prefer a value-span box over a long quote box.
- Match numeric and punctuation variants when attaching **parser-backed** COCO boxes. Still never invent boxes or take them from the model.
- Rebind model field paths that drop indexes (`qty` → `lines[0].qty`) onto the extracted output.
- Deduplicate same field+page, keeping the citation with a box.
- Tests for the above; CHANGELOG under Unreleased; `docs/extractbench.md` notes grounding work is in progress (no invented smoke scores).
- **No package version bump.**

## Testing

- `uv run pytest -n auto --cov=openextract --cov-fail-under=100` — 803 passed, 100% coverage
- `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check` — clean
- No live OpenRouter / 370-doc ExtractBench run (out of scope)

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74ae8d75-9e3a-4582-bfea-934e4f9cfe9d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74ae8d75-9e3a-4582-bfea-934e4f9cfe9d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

