### PR TITLE
fix: make 0.13.1 PyPI publish accept wheel metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Publish to PyPI
         if: steps.check_release.outputs.exists == 'false'
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33  # v1.14.2
 
       - name: Create GitHub Release
         if: steps.check_release.outputs.exists == 'false'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ timing when that is known.
 
 ## [Unreleased]
 
+### Fixed
+- Release publish accepts hatchling wheels that emit Metadata-Version 2.5
+  (`pypa/gh-action-pypi-publish` v1.14.2 / Twine 7). 0.13.1 build succeeded
+  but PyPI upload failed on the older action pin.
+
 ## [0.13.1] - 2026-09-11
 
 ### Fixed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

0.13.1 built cleanly but **Publish to PyPI** failed with `InvalidDistribution: '2.5' is not a valid metadata version`. GitHub Release was skipped; PyPI is still 0.13.0 and there is no `v0.13.1` tag.

`uv build` uses unconstrained hatchling. hatchling 1.32.0 writes `Metadata-Version: 2.5`. The release workflow was pinned to `pypa/gh-action-pypi-publish` `cef2210` (v1.14.0 / Twine 6), which cannot parse 2.5.

## Changes

- Pin `pypa/gh-action-pypi-publish` to `dc37677` (**v1.14.2**), which bundles Twine 7 and accepts Metadata-Version 2.5 for upload to PyPI.
- Unreleased changelog note only. **No package version bump** (stays 0.13.1).

No hatchling pin: Warehouse already accepts 2.5; the failure was the outdated action’s Twine 6 pre-upload check.

## Testing

Local `uv build` (hatchling 1.32.0):

```
Metadata-Version: 2.5
Generator: hatchling 1.32.0
```

- `uvx twine==7.0.0 check dist/*` → **PASSED** (wheel + sdist)
- `uvx twine==6.1.0 check dist/*` → **ERROR** `'2.5' is not a valid metadata version` (same as the failed Release run)
- PR CI is green (lint, tests, package)

## After merge

Do **not** re-run the failed Release job (it still has the old workflow). Merge this, let CI pass on `main`, and let the `workflow_run` Release start a new publish of 0.13.1.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e05dc9c-f921-4ee5-9377-3b911d7c3d47?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e05dc9c-f921-4ee5-9377-3b911d7c3d47&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

