### PR TITLE
docs: refresh ExtractBench status after grounding fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ timing when that is known.
 
 ## [Unreleased]
 
+### Changed
+- ExtractBench docs: latest smoke notes that `0.13.1+` includes page/word
+  grounding fixes (#220); the published 6-doc numbers remain the pre-fix
+  `0.13.0` run (page F1 0.24). A fresh smoke has not been published; the
+  gate is still unmet until that run.
+
 ### Fixed
 - Release publish accepts hatchling wheels that emit Metadata-Version 2.5
   (`pypa/gh-action-pypi-publish` v1.14.2 / Twine 7). 0.13.1 build succeeded

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -106,12 +106,16 @@ retried at file level. Scanned / empty-text PDFs are rendered to compact graysca
 never uploaded for provider document-parse. Citations are collected from
 every window before reduce. One-page windows remap model `page=1` / missing
 pages onto the document page in that window. When a window
-returns values but no cites — or a cite whose quote is paraphrased — pages
-are located from the extracted values in the local parse
-(including numeric display variants). Boxes are never invented and are never
-taken from the model: if a parser span matches the quote (exact, then simple
-fuzzy), a normalized COCO `[x, y, width, height]` in `[0, 1]` is attached; if
-nothing matches, `bbox` is omitted. Citations without a page cannot become
+returns values but no cites — or a cite whose quote is paraphrased, or whose
+hinted page is a false match — pages are located from the extracted values in
+the local parse (including numeric and punctuation variants such as
+`$1,234.00` vs `1234`). Boxes are never invented and are never
+taken from the model: if a parser span matches the quote or value (exact,
+then simple fuzzy), a normalized COCO `[x, y, width, height]` in `[0, 1]` is
+attached, preferring the value span over a long quote box; if
+nothing matches, `bbox` is omitted. Model field paths that drop array
+indexes (`qty` vs `lines[0].qty`) are rebound onto the extracted output.
+Citations without a page cannot become
 `FieldCitation` (ExtractBench requires `page >= 1`) and are dropped at the
 mapping step.
 
@@ -125,13 +129,19 @@ full run is 370 documents / 4,869 pages and is metered API usage.
 
 ## Latest smoke
 
-Local 6-document `--test` on OpenRouter `z-ai/glm-5.3-flash` (citations on,
-package `0.13.0`) finished 6/6 inference. Successful-only page F1 was 0.24,
-below the maintainer gate (6/6 finish **and** successful-only page F1 > 0.37).
-Page and word grounding (window page assignment and parser box attachment) is
-in progress in this repository; that smoke number is from before this work and
-is not a new run. The full 370-document run has not been run. Listing this
-pipeline on the official ExtractBench leaderboard is a later change in
+The last published 6-document `--test` (OpenRouter `z-ai/glm-5.3-flash`,
+citations on, package `0.13.0`) finished 6/6 inference with successful-only
+page F1 of 0.24. That is a **pre-fix** smoke from before the page/word
+grounding work shipped in `0.13.1` ([#220](https://github.com/Mellow-Artificial-Intelligence/openextract/pull/220)):
+window page remap, value backfill when the quote is paraphrased or the hinted
+page is wrong, and parser boxes for numeric/punctuation variants. Those
+numbers are not a new run.
+
+Package `0.13.1+` includes those fixes. A fresh 6-doc smoke on that tree has
+not been published yet. The maintainer gate (6/6 finish **and** successful-only
+page F1 > 0.37) is still unmet until that run is posted. The full 370-document
+run has not been run. Listing this pipeline on the official ExtractBench
+leaderboard is a later change in
 [run-llama/ExtractBench](https://github.com/run-llama/ExtractBench), not this
 repository.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refresh `docs/extractbench.md` Latest smoke / Grounding after 0.13.1 shipped the page/word grounding fixes from #220. No new smoke scores are invented.

## Changes

- Latest smoke: package is `0.13.1+` with grounding fixes merged (window page remap, value backfill, numeric/punct boxes).
- Keep the published 6-doc numbers (6/6 finish, successful-only page F1 0.24) labeled as the **pre-fix** `0.13.0` smoke.
- State that a fresh 6-doc run has not been published yet, so the maintainer gate is still unmet.
- Small Grounding section clarifications (false-match page backfill, numeric/punct variants, value-span box preference, field-path rebind).
- CHANGELOG Unreleased under Changed. No version bump. No code changes.

## Testing

- Docs-only review of `docs/extractbench.md` and `CHANGELOG.md`.
- Confirmed the 0.24 page F1 figure is unchanged from the last published 0.13.0 smoke.

## Checklist

- [x] Tests pass locally (`uv run pytest`) — N/A, docs only
- [x] Linting passes (`uv run ruff check .`) — N/A, docs only
- [x] Documentation updated (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bab87f39-fe76-48f0-ace6-c990d1784df7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bab87f39-fe76-48f0-ace6-c990d1784df7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

