### PR TITLE
docs: polish citation guidance for agents and guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ timing when that is known.
   grounding fixes (#220); the published 6-doc numbers remain the pre-fix
   `0.13.0` run (page F1 0.24). A fresh smoke has not been published; the
   gate is still unmet until that run.
+- Docs: citation guidance in the guide and agent contract now covers page
+  remap, value-backfill, and parser-backed boxes (`openextract[pdf]`).
 
 ### Fixed
 - Release publish accepts hatchling wheels that emit Metadata-Version 2.5

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -47,7 +47,7 @@ Always define a real `pydantic.BaseModel` subclass. Do not ask the library for f
 | Many inputs, want a list | `extract_many` (sync, **not** from a running loop) or `extract_many_async` |
 | Many inputs, stream as done | `iter_extract_many_async` — yields `(input_index, result)` in **completion order** |
 | Per-item usage / timing | `extract_many_with_results*` + `total_usage` |
-| Per-field source spans (ExtractBench grounding) | `cite=True` + `extract_many_with_results*` → `ExtractionResult.citations` |
+| Per-field source spans (ExtractBench grounding) | `cite=True` on `extract_many_with_results*` or sessions (`Extractor` / `AsyncExtractor`). Read `ExtractionResult.citations`; session `extract()` still returns the schema instance. |
 | Several agents on **one** input | `extract_swarm` / `extract_swarm_async` |
 | A reusable specialist (model + style + instructions + schema) | `define_agent`, then `extract(agent, input_file)` or `agents=` |
 | An extraction service over HTTP | `define_remote_agent` + `openextract.auth` |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -141,10 +141,17 @@ print(usage.input_tokens, usage.output_tokens, usage.total_tokens)
 
 `cite=True` asks the model for per-field source evidence (a quote and
 1-indexed page). PDFs are parsed locally first; long documents are chunked by
-page so the model never sees the whole parse as one prompt. `bbox` is attached
-only when the parser matches the quoted span. `extract()` still returns the
-schema instance. Read citations from `ExtractionResult.citations` on
-`extract_many_with_results*` / `extract_swarm_with_results*`.
+page so the model never sees the whole parse as one prompt.
+
+One-page windows remap `page=1` / missing pages onto the document page the
+model actually saw. If the quote is paraphrased or the page is wrong, the page
+is backfilled from the extracted field value. `bbox` is parser-backed only —
+attached when the local parser matches the span, never invented. Boxes need
+`openextract[pdf]`.
+
+`extract()` still returns the schema instance. Read citations from
+`ExtractionResult.citations` on `extract_many_with_results*` /
+`extract_swarm_with_results*`.
 
 ```python
 from openextract import extract_many_with_results


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Polish user- and agent-facing citation docs ahead of a minor release. No version bump, no code.

## Changes

- `docs/guide.md` Citations: page remap, value-backfill, and parser-backed boxes at a high level; note `openextract[pdf]` for boxes.
- `docs/agents.md`: cite row now matches the current API (`extract_many_with_results*`, `Extractor` / `AsyncExtractor`) and that session `extract()` still returns the schema instance.
- `CHANGELOG.md` Unreleased: Changed docs. `docs/index.html` what's-new left for the release PR.

## Testing

- Docs-only. Reviewed the citation wording against the current `cite=True` / `ExtractionResult.citations` surfaces.
- No pytest or ruff run (no code).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e46e35dd-1627-452a-800a-301dc9bdaed6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e46e35dd-1627-452a-800a-301dc9bdaed6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

