### PR TITLE
feat: Citation.as_dict for stable JSON citations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ timing when that is known.
 
 ## [Unreleased]
 
+### Added
+- `Citation.as_dict()` returns a JSON-stable `{field, quote, page, bbox}`
+  payload (`bbox` is a list of four floats or `null`). Boxes stay
+  parser-backed; `as_field_citation()` ExtractBench mapping is unchanged.
+
 ### Changed
 - ExtractBench docs: latest smoke notes that `0.13.1+` includes page/word
   grounding fixes (#220); the published 6-doc numbers remain the pre-fix

--- a/README.md
+++ b/README.md
@@ -643,7 +643,7 @@ below even though it is not exported from `__all__`.
 | `total_usage` | Provisional | Sum `Usage` across batch `ExtractionResult` objects. |
 | `ExtractionInput` | Provisional | Frozen input contract wrapping a media source with optional per-item `media_type` and safe `name`. |
 | `ExtractionResult` | Provisional | Frozen generic result contract; never retains raw media, credentials, or provider internals. Additive `citations` when `cite=True`. |
-| `Citation` | Provisional | Per-field source span (`field`, `quote`, `page`, optional normalized `bbox`). `as_field_citation()` maps to ExtractBench `FieldCitation`. |
+| `Citation` | Provisional | Per-field source span (`field`, `quote`, `page`, optional normalized `bbox`). `as_dict()` is the JSON shape (`bbox` as four floats or `null`). `as_field_citation()` maps to ExtractBench `FieldCitation`. |
 | `Usage` | Stable | Frozen dataclass with `input_tokens`, `output_tokens`, and `total_tokens`. New fields, if ever needed, should be additive. |
 | `ExtractionError` | Stable | Base class for all public `openextract` exceptions. Catch this for a broad fallback. |
 | `UrlFetchError` | Stable | Raised for URL fetch and URL safety failures. Message wording may improve, but the exception type is stable. |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -360,8 +360,11 @@ A frozen dataclass for one field's source evidence. Mapped onto ExtractBench
 | `page` | `int \| None` | 1-indexed page. Required to emit an ExtractBench citation. |
 | `bbox` | `tuple[float, float, float, float] \| None` | Normalized COCO `(x, y, width, height)` in `[0, 1]`. Kept only when a local parser matched the span; never invented. |
 
-`as_field_citation()` returns `None` when `page` is missing (quote-only
-citations stay on `ExtractionResult` but cannot be scored by ExtractBench).
+`as_dict()` is the JSON shape for CLI and other consumers:
+`{field, quote, page, bbox}` with `bbox` as a list of four floats or `null`.
+Quote-only citations are included. `as_field_citation()` returns `None` when
+`page` is missing (those citations stay on `ExtractionResult` but cannot be
+scored by ExtractBench).
 
 ### `ExtractionResult`
 

--- a/docs/extractbench.md
+++ b/docs/extractbench.md
@@ -75,7 +75,9 @@ scans are not rejected by openextract's 50 MiB library default.
 ## Grounding
 
 The runner asks the model for per-field citations by default (`--cite`, disable
-with `--no-cite`) and maps them onto ExtractBench `FieldCitation`:
+with `--no-cite`). Raw `citations` in the result JSON use
+`Citation.as_dict()` (`field`, `quote`, `page`, `bbox` as four floats or
+`null`). ExtractBench scoring still uses `as_field_citation()` / `FieldCitation`:
 
 | ExtractBench field | openextract `Citation` | When it scores |
 | --- | --- | --- |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -160,7 +160,7 @@ results = extract_many_with_results(
     schema=Invoice, model="openai:gpt-5", input_files=["bill.pdf"], cite=True
 )
 for citation in results[0].citations:
-    print(citation.field, citation.page, citation.quote)
+    print(citation.as_dict())
 ```
 
 Default is off: no extra instructions or schema wrap. Citations never retain

--- a/scripts/extractbench.py
+++ b/scripts/extractbench.py
@@ -799,15 +799,7 @@ def register_openextract_pipeline(
                 ) + out_tok / 1_000_000 * float(cfg.get("output_price_per_1m", 0.0))
                 raw_output = {
                     "data": extracted,
-                    "citations": [
-                        {
-                            "field": citation.field,
-                            "quote": citation.quote,
-                            "page": citation.page,
-                            "bbox": list(citation.bbox) if citation.bbox is not None else None,
-                        }
-                        for citation in citations
-                    ],
+                    "citations": [citation.as_dict() for citation in citations],
                     "field_citations": field_citations_for_extractbench(citations),
                     "model": cfg["model"],
                     "usage": {

--- a/src/openextract/_types.py
+++ b/src/openextract/_types.py
@@ -84,6 +84,21 @@ class Citation:
     page: int | None = None
     bbox: tuple[float, float, float, float] | None = None
 
+    def as_dict(self) -> dict[str, object]:
+        """JSON-stable citation: ``field``, ``quote``, ``page``, ``bbox``.
+
+        ``bbox`` is a list of four floats when a local parser located the
+        span, otherwise ``None``. Boxes are never invented. Quote-only
+        citations are included; :meth:`as_field_citation` still requires a
+        page for ExtractBench scoring.
+        """
+        return {
+            "field": self.field,
+            "quote": self.quote,
+            "page": self.page,
+            "bbox": list(self.bbox) if self.bbox is not None else None,
+        }
+
     def as_field_citation(self) -> dict[str, object] | None:
         """ExtractBench ``FieldCitation`` payload, or ``None`` without a page.
 
@@ -93,11 +108,12 @@ class Citation:
         """
         if self.page is None:
             return None
+        dumped = self.as_dict()
         return {
-            "field_path": self.field,
-            "page": self.page,
-            "bbox": list(self.bbox) if self.bbox is not None else None,
-            "reference_text": self.quote,
+            "field_path": dumped["field"],
+            "page": dumped["page"],
+            "bbox": dumped["bbox"],
+            "reference_text": dumped["quote"],
         }
 
 

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from pydantic import BaseModel
 from pydantic_ai.models.test import TestModel
 
@@ -43,6 +45,33 @@ def _cited_model(**kwargs: object) -> TestModel:
 
 
 class TestCitationMapping:
+    def test_as_dict_is_json_stable(self):
+        citation = Citation(
+            field="lines[0].qty",
+            quote="3",
+            page=1,
+            bbox=(0.1, 0.2, 0.3, 0.05),
+        )
+        dumped = citation.as_dict()
+        assert dumped == {
+            "field": "lines[0].qty",
+            "quote": "3",
+            "page": 1,
+            "bbox": [0.1, 0.2, 0.3, 0.05],
+        }
+        assert json.loads(json.dumps(dumped)) == dumped
+
+    def test_as_dict_includes_quote_only_without_inventing_bbox(self):
+        quote_only = Citation(field="vendor", quote="Acme")
+        assert quote_only.as_dict() == {
+            "field": "vendor",
+            "quote": "Acme",
+            "page": None,
+            "bbox": None,
+        }
+        assert quote_only.as_field_citation() is None
+        assert field_citations_for_extractbench([quote_only]) == []
+
     def test_as_field_citation_requires_page(self):
         quote_only = Citation(field="vendor", quote="Acme")
         assert quote_only.as_field_citation() is None

--- a/tests/typing/consumer.py
+++ b/tests/typing/consumer.py
@@ -71,8 +71,10 @@ _assert_invoice: Invoice = output
 _assert_usage: Usage = usage
 cited: Invoice = extract(Invoice, "openai:gpt-5", Path("/tmp/x.pdf"), cite=True)
 _cite: Citation = Citation("total", "12.50", 1, (0.1, 0.2, 0.3, 0.05))
+_dumped: dict[str, object] = _cite.as_dict()
 _field: dict[str, object] | None = _cite.as_field_citation()
 _ = cited
+_ = _dumped
 _ = _field
 
 # extract_many_with_results returns ExtractionResult[Invoice] (or + Exception).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `Citation.as_dict()` so CLI/JSON consumers can dump citations as `{field, quote, page, bbox}` without inventing boxes or changing ExtractBench mapping.

Rebased onto latest `main` (docs polish from #222/#223). CHANGELOG keeps both Unreleased Added (`as_dict`) and Changed (citation/ExtractBench docs). `__init__.py` did not conflict. No version bump.

## Changes

- `Citation.as_dict()` returns a JSON-stable payload; `bbox` is a list of four floats or `null`
- `as_field_citation()` still requires a page and still emits ExtractBench `FieldCitation` keys
- ExtractBench raw `citations` JSON now uses `as_dict()`; `field_citations` mapping is unchanged
- Docs (API reference, guide, README, ExtractBench) and CHANGELOG Unreleased (Added)

## Testing

- `uv run pytest tests/test_citations.py tests/test_extractbench.py tests/test_typing.py`: 78 passed
- `uv run ruff check .` / `ruff format --check .`: passed
- New coverage: JSON round-trip, quote-only dump (no invented bbox), existing ExtractBench mapping tests, typing consumer for `as_dict()`

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3323b30f-5af7-42cd-b2dc-d44ff0919b71?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3323b30f-5af7-42cd-b2dc-d44ff0919b71&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

