### PR TITLE
feat(cli): add --cite with citations in JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ timing when that is known.
 - `Citation.as_dict()` returns a JSON-stable `{field, quote, page, bbox}`
   payload (`bbox` is a list of four floats or `null`). Boxes stay
   parser-backed; `as_field_citation()` ExtractBench mapping is unchanged.
+- CLI `--cite` requests per-field citations via the same `cite=True` library
+  path (parse-then-extract when the PDF extra is available). JSON and JSONL
+  include a `citations` array of `{field, quote, page}` objects with optional
+  `bbox`. An injected agent still raises `ValueError`, as in the library.
 
 ### Changed
 - ExtractBench docs: latest smoke notes that `0.13.1+` includes page/word

--- a/README.md
+++ b/README.md
@@ -532,6 +532,8 @@ cat ./reports/q4.pdf | openextract - \
   display names; mutually exclusive with positional inputs.
 - `--usage` prints `result` and `usage` for a single input; batches report
   per-item usage plus an aggregate.
+- `--cite` requests per-field citations (`{field, quote, page}`, optional
+  `bbox`) in JSON/jsonl via the same `cite=True` library path.
 - `--output` is `json` (default), `jsonl` (one record per completed input,
   written incrementally in completion order with an `index` field), or `repr`.
 - `--max-concurrency` bounds in-flight extractions for batches (default 5).

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -195,6 +195,40 @@ openextract ./invoices/a.pdf ./invoices/b.pdf \
 The aggregate sums successful items only. With `--output jsonl`, usage appears
 on each success record and in the final `summary` line instead.
 
+## `--cite` output
+
+`--cite` asks the model for per-field source evidence, the same as
+`cite=True` on the Python API. PDFs are parsed locally first when
+`openextract[pdf]` is installed. Default is off; non-cite JSON shapes are
+unchanged.
+
+```bash
+openextract ./reports/q4.pdf \
+  --schema mypkg.schemas:Invoice \
+  --model xai:grok-4.3 \
+  --cite
+```
+
+```json
+{
+  "result": { "...": "schema fields" },
+  "citations": [
+    { "field": "vendor", "quote": "Acme", "page": 1 },
+    { "field": "total", "quote": "12.50", "page": 1, "bbox": [0.1, 0.2, 0.3, 0.05] }
+  ]
+}
+```
+
+Each citation is `{field, quote, page}` with optional `bbox` (normalized COCO,
+parser-backed only). `quote` / `page` may be `null`. Combine with `--usage` to
+keep `{result, usage, citations}`.
+
+- Batch JSON array: `[{ "result", "citations" }, ...]` in input order.
+- JSONL success records add `"citations"`; failure records are unchanged.
+- Swarms merge citations from successful agents.
+- An injected Pydantic AI agent cannot be used with `--cite` (exit `1`, same
+  `ValueError` as `Extractor(agent=..., cite=True)`).
+
 ## `--output json`, `--output jsonl`, and `--output repr`
 
 | Flag | Behavior |

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -366,6 +366,8 @@ openextract ./bill.pdf \
 - `--schema` is `module:ClassName` on `PYTHONPATH`.
 - Batch: pass multiple paths. `--continue-on-error` emits per-item errors inline and exits `7` if any failed.
 - `--usage` is single-input only.
+- `--cite` adds a `citations` array to JSON/jsonl (`field`, `quote`, `page`,
+  optional `bbox`). Same as `cite=True` on the Python API.
 - `--style`, `--max-retries`, `--max-input-bytes` match the Python API.
 
 Full stdout/stderr/exit-code contract: [CLI](cli.md).

--- a/src/openextract/_cli.py
+++ b/src/openextract/_cli.py
@@ -14,14 +14,14 @@ from typing import Any, BinaryIO, cast
 from dotenv import load_dotenv
 from pydantic import BaseModel
 
-from ._agents import DefinedAgent, RemoteAgent, load_agent, load_agents
-from ._batch import _BatchOptions, _iter_extractions
+from ._agents import DefinedAgent, RemoteAgent, is_agent, load_agent, load_agents
+from ._batch import _BatchOptions, _iter_extractions, extract_many_with_results
 from ._config import _validate_max_concurrency
-from ._extract import extract, extract_with_usage
+from ._extract import _plan_agent, extract, extract_with_usage
 from ._reduce import SwarmReduce
 from ._styles import ExtractionStyle
 from ._swarm import extract_swarm, extract_swarm_with_results
-from ._types import ExtractionInput, ExtractionInputLike, ExtractionResult
+from ._types import Citation, ExtractionInput, ExtractionInputLike, ExtractionResult
 from .exceptions import (
     ExtractionError,
     ModelError,
@@ -211,6 +211,41 @@ def _usage_payload(usage) -> dict[str, int]:
     }
 
 
+def _citations_payload(citations: Sequence[Citation]) -> list[dict[str, Any]]:
+    """Serialize citations as ``{field, quote, page}`` plus optional ``bbox``."""
+    payload: list[dict[str, Any]] = []
+    for citation in citations:
+        item: dict[str, Any] = {
+            "field": citation.field,
+            "quote": citation.quote,
+            "page": citation.page,
+        }
+        if citation.bbox is not None:
+            item["bbox"] = list(citation.bbox)
+        payload.append(item)
+    return payload
+
+
+def _result_dump(result: object) -> dict[str, Any]:
+    if isinstance(result, ExtractionResult):
+        return cast(BaseModel, result.output).model_dump()
+    return cast(BaseModel, result).model_dump()
+
+
+def _result_citations(result: object) -> list[dict[str, Any]]:
+    if isinstance(result, ExtractionResult):
+        return _citations_payload(result.citations)
+    return []
+
+
+def _swarm_citations(swarm: Any) -> list[dict[str, Any]]:
+    citations: list[Citation] = []
+    for agent in swarm.agents:
+        if isinstance(agent, ExtractionResult):
+            citations.extend(agent.citations)
+    return _citations_payload(citations)
+
+
 def _failure_record(label: str, error: BaseException) -> dict[str, Any]:
     return {
         "input": label,
@@ -219,25 +254,37 @@ def _failure_record(label: str, error: BaseException) -> dict[str, Any]:
     }
 
 
-def _item_record(label: str, result: object, *, with_usage: bool) -> dict[str, Any]:
+def _item_record(
+    label: str,
+    result: object,
+    *,
+    with_usage: bool,
+    with_citations: bool,
+) -> dict[str, Any]:
     """Build the labeled record for one completed batch item."""
     if isinstance(result, BaseException):
         return _failure_record(label, result)
+    record: dict[str, Any] = {"input": label, "result": _result_dump(result)}
     if with_usage:
-        rich = cast(ExtractionResult[Any], result)
-        return {
-            "input": label,
-            "result": rich.output.model_dump(),
-            "usage": _usage_payload(rich.usage),
-        }
-    return {"input": label, "result": cast(BaseModel, result).model_dump()}
+        record["usage"] = _usage_payload(cast(ExtractionResult[Any], result).usage)
+    if with_citations:
+        record["citations"] = _result_citations(result)
+    return record
 
 
-def _array_entry(label: str, result: object, *, with_usage: bool) -> Any:
+def _array_entry(
+    label: str,
+    result: object,
+    *,
+    with_usage: bool,
+    with_citations: bool,
+) -> Any:
     """Build one JSON-array entry, keeping the legacy bare shape for successes."""
     if with_usage or isinstance(result, BaseException):
-        return _item_record(label, result, with_usage=with_usage)
-    return cast(BaseModel, result).model_dump()
+        return _item_record(label, result, with_usage=with_usage, with_citations=with_citations)
+    if with_citations:
+        return {"result": _result_dump(result), "citations": _result_citations(result)}
+    return _result_dump(result)
 
 
 def _print_json(payload: Any, *, as_repr: bool) -> None:
@@ -268,12 +315,19 @@ def _print_batch_payload(
     usage_totals: dict[str, int],
     *,
     with_usage: bool,
+    with_citations: bool,
     as_repr: bool,
 ) -> None:
     """Emit the buffered batch payload in input order."""
     ordered.sort(key=lambda pair: pair[0])
     entries = [
-        _array_entry(labels[index], result, with_usage=with_usage) for index, result in ordered
+        _array_entry(
+            labels[index],
+            result,
+            with_usage=with_usage,
+            with_citations=with_citations,
+        )
+        for index, result in ordered
     ]
     payload: Any = {"results": entries, "usage": usage_totals} if with_usage else entries
     _print_json(payload, as_repr=as_repr)
@@ -288,7 +342,8 @@ async def _run_batch_async(
     model: str,
 ) -> int:
     """Stream the batch, emitting records (JSONL) or buffering them (array)."""
-    with_usage = options.rich
+    with_usage = args.usage
+    with_citations = args.cite
     jsonl = args.output == "jsonl"
     # _iter_extractions is an async generator function; its AsyncIterator return
     # annotation hides the aclose() needed for deterministic finalization.
@@ -312,7 +367,12 @@ async def _run_batch_async(
                 usage_totals["output_tokens"] += usage.output_tokens
                 usage_totals["total_tokens"] += usage.total_tokens
             if jsonl:
-                record = _item_record(labels[index], result, with_usage=with_usage)
+                record = _item_record(
+                    labels[index],
+                    result,
+                    with_usage=with_usage,
+                    with_citations=with_citations,
+                )
                 _emit_json_line({"index": index, **record})
             else:
                 ordered.append((index, result))
@@ -336,6 +396,7 @@ async def _run_batch_async(
             labels,
             usage_totals,
             with_usage=with_usage,
+            with_citations=with_citations,
             as_repr=args.output == "repr",
         )
 
@@ -366,7 +427,8 @@ def _run_batch(
         max_retries=args.max_retries,
         retry_backoff=args.retry_backoff,
         retry_max_backoff=args.retry_max_backoff,
-        rich=args.usage,
+        rich=args.usage or args.cite,
+        cite=args.cite,
     )
     return asyncio.run(_run_batch_async(schema_cls, items, labels, options, args, model))
 
@@ -388,32 +450,43 @@ def _run_single(
     model: str | DefinedAgent | RemoteAgent,
 ) -> int:
     """Run a single extraction with the legacy output shapes."""
-    if args.usage:
+    shared: dict[str, Any] = {
+        "instructions": args.instructions,
+        "style": args.style,
+        "media_type": args.media_type,
+        "max_input_bytes": args.max_input_bytes,
+        "max_retries": args.max_retries,
+        "retry_backoff": args.retry_backoff,
+        "retry_max_backoff": args.retry_max_backoff,
+        "cite": args.cite,
+    }
+    if args.cite:
+        run_model: Any = model
+        if is_agent(model):
+            run_model, shared["instructions"], shared["style"], use_swarm = _plan_agent(
+                model, args.instructions, args.style
+            )
+            if use_swarm:
+                return _run_swarm(schema_cls, [model], input_file, args)
+        rich = extract_many_with_results(schema_cls, run_model, [input_file], **shared)[0]
+        payload: Any = {"result": rich.output.model_dump()}
+        if args.usage:
+            payload["usage"] = _usage_payload(rich.usage)
+        payload["citations"] = _citations_payload(rich.citations)
+    elif args.usage:
         result, usage = extract_with_usage(
             schema=schema_cls,
             model=model,
             input_file=input_file,
-            instructions=args.instructions,
-            style=args.style,
-            media_type=args.media_type,
-            max_input_bytes=args.max_input_bytes,
-            max_retries=args.max_retries,
-            retry_backoff=args.retry_backoff,
-            retry_max_backoff=args.retry_max_backoff,
+            **shared,
         )
-        payload: Any = {"result": result.model_dump(), "usage": _usage_payload(usage)}
+        payload = {"result": result.model_dump(), "usage": _usage_payload(usage)}
     else:
         payload = extract(
             schema=schema_cls,
             model=model,
             input_file=input_file,
-            instructions=args.instructions,
-            style=args.style,
-            media_type=args.media_type,
-            max_input_bytes=args.max_input_bytes,
-            max_retries=args.max_retries,
-            retry_backoff=args.retry_backoff,
-            retry_max_backoff=args.retry_max_backoff,
+            **shared,
         )
 
     _print_single_payload(payload, args)
@@ -437,15 +510,17 @@ def _run_swarm(
         "max_retries": args.max_retries,
         "retry_backoff": args.retry_backoff,
         "retry_max_backoff": args.retry_max_backoff,
+        "cite": args.cite,
     }
-    if args.usage:
+    if args.usage or args.cite:
         swarm = extract_swarm_with_results(schema_cls, swarm_agents, input_file, **options)
-        payload: Any = {
-            "result": swarm.output.model_dump(),
-            "usage": _usage_payload(swarm.usage),
-            "agents": len(swarm.agents),
-            "reduce": swarm.reduce.value,
-        }
+        payload: Any = {"result": swarm.output.model_dump()}
+        if args.usage:
+            payload["usage"] = _usage_payload(swarm.usage)
+            payload["agents"] = len(swarm.agents)
+            payload["reduce"] = swarm.reduce.value
+        if args.cite:
+            payload["citations"] = _swarm_citations(swarm)
     else:
         payload = extract_swarm(schema_cls, swarm_agents, input_file, **options)
     _print_single_payload(payload, args)
@@ -548,6 +623,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Include token usage: single inputs keep the {result, usage} shape; "
             "batches report per-item and aggregate usage."
+        ),
+    )
+    parser.add_argument(
+        "--cite",
+        action="store_true",
+        help=(
+            "Request per-field source citations (field, quote, page, optional bbox). "
+            "JSON/jsonl include a citations array. Same cite=True path as the library."
         ),
     )
     parser.add_argument(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ import pytest
 from pydantic import BaseModel
 
 from openextract import (
+    Citation,
     ExtractionError,
     ExtractionInput,
     ExtractionResult,
@@ -20,7 +21,13 @@ from openextract import (
     UrlFetchError,
     Usage,
 )
-from openextract._cli import _discard_stdout, _resolve_schema, main
+from openextract._cli import (
+    _citations_payload,
+    _discard_stdout,
+    _resolve_schema,
+    _result_citations,
+    main,
+)
 
 
 class _FixtureSchema(BaseModel):
@@ -62,7 +69,7 @@ def _patch_iter_extractions(mocker, events=(), error=None):
     return mocker.patch("openextract._cli._iter_extractions", side_effect=_stream)
 
 
-def _rich_result(output, input_tokens=10, output_tokens=5):
+def _rich_result(output, input_tokens=10, output_tokens=5, citations=()):
     return ExtractionResult(
         output=output,
         usage=Usage(input_tokens, output_tokens, input_tokens + output_tokens),
@@ -71,7 +78,17 @@ def _rich_result(output, input_tokens=10, output_tokens=5):
         model="xai:grok-4.3",
         media_type=None,
         source="fixture",
+        citations=citations,
     )
+
+
+def _patch_extract_many_with_results(mocker, return_value=None, side_effect=None):
+    mock_fn = mocker.patch("openextract._cli.extract_many_with_results")
+    if side_effect is not None:
+        mock_fn.side_effect = side_effect
+    else:
+        mock_fn.return_value = return_value
+    return mock_fn
 
 
 _BASE_ARGS = ["--schema", "tests.test_cli:_FixtureSchema", "--model", "xai:grok-4.3"]
@@ -190,6 +207,7 @@ class TestMainSuccess:
             max_retries=0,
             retry_backoff=1.0,
             retry_max_backoff=60.0,
+            cite=False,
         )
 
     def test_repr_output(self, mocker, capsys):
@@ -1010,3 +1028,218 @@ class TestRemoteAgentExit:
 
         assert main(["input.txt", *_BASE_ARGS, "--model", "test:a"]) == 8
         assert "agent unreachable" in capsys.readouterr().err
+
+
+_CITE_NAME = Citation(field="name", quote="Ada", page=1)
+_CITE_AGE = Citation(field="age", quote="36", page=1, bbox=(0.1, 0.2, 0.3, 0.05))
+
+
+class TestCite:
+    def test_citations_payload_omits_missing_bbox(self):
+        assert _citations_payload((_CITE_NAME, _CITE_AGE)) == [
+            {"field": "name", "quote": "Ada", "page": 1},
+            {"field": "age", "quote": "36", "page": 1, "bbox": [0.1, 0.2, 0.3, 0.05]},
+        ]
+        assert _result_citations(_FixtureSchema(name="Ada", age=36)) == []
+
+    def test_cite_flag_is_forwarded_to_results_api(self, mocker, capsys):
+        mock_fn = _patch_extract_many_with_results(
+            mocker,
+            return_value=[
+                _rich_result(_FixtureSchema(name="Ada", age=36), citations=(_CITE_NAME,))
+            ],
+        )
+
+        assert main(["input.txt", *_BASE_ARGS, "--cite"]) == 0
+
+        assert mock_fn.call_args.kwargs["cite"] is True
+        payload = json.loads(capsys.readouterr().out)
+        assert payload == {
+            "result": {"name": "Ada", "age": 36},
+            "citations": [{"field": "name", "quote": "Ada", "page": 1}],
+        }
+
+    def test_cite_json_includes_optional_bbox(self, mocker, capsys):
+        _patch_extract_many_with_results(
+            mocker,
+            return_value=[
+                _rich_result(_FixtureSchema(name="Ada", age=36), citations=(_CITE_NAME, _CITE_AGE))
+            ],
+        )
+
+        assert main(["input.txt", *_BASE_ARGS, "--cite"]) == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["citations"][1]["bbox"] == [0.1, 0.2, 0.3, 0.05]
+        assert "bbox" not in payload["citations"][0]
+
+    def test_cite_with_usage_keeps_usage_shape(self, mocker, capsys):
+        _patch_extract_many_with_results(
+            mocker,
+            return_value=[
+                _rich_result(
+                    _FixtureSchema(name="Ada", age=36),
+                    input_tokens=10,
+                    output_tokens=5,
+                    citations=(_CITE_NAME,),
+                )
+            ],
+        )
+
+        assert main(["input.txt", *_BASE_ARGS, "--cite", "--usage"]) == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["usage"] == {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15}
+        assert payload["citations"] == [{"field": "name", "quote": "Ada", "page": 1}]
+
+    def test_cite_json_payload_with_test_model(self, mocker, tmp_path, capsys):
+        from pydantic_ai.models.test import TestModel
+
+        from openextract._batch import extract_many_with_results
+
+        source = tmp_path / "doc.txt"
+        source.write_text("Ada Lovelace, 36", encoding="utf-8")
+
+        def _run(schema, model, input_files, **kwargs):
+            return extract_many_with_results(
+                schema,
+                TestModel(
+                    custom_output_args={
+                        "output": {"name": "Ada", "age": 36},
+                        "citations": [{"field": "name", "quote": "Ada Lovelace", "page": 1}],
+                    }
+                ),
+                input_files,
+                **kwargs,
+            )
+
+        mocker.patch("openextract._cli.extract_many_with_results", side_effect=_run)
+
+        assert main([str(source), *_BASE_ARGS, "--cite"]) == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["result"] == {"name": "Ada", "age": 36}
+        assert payload["citations"] == [
+            {"field": "name", "quote": "Ada Lovelace", "page": 1},
+        ]
+
+    def test_cite_without_flag_does_not_change_output(self, mocker, capsys):
+        _patch_extract(mocker, return_value=_FixtureSchema(name="Ada", age=36))
+
+        assert main(["input.txt", *_BASE_ARGS]) == 0
+
+        assert json.loads(capsys.readouterr().out) == {"name": "Ada", "age": 36}
+
+    def test_injected_agent_error_exits_one(self, mocker, capsys):
+        _patch_extract_many_with_results(
+            mocker,
+            side_effect=ValueError("cite cannot be used with an injected agent."),
+        )
+
+        assert main(["input.txt", *_BASE_ARGS, "--cite"]) == 1
+        assert "cite cannot be used with an injected agent" in capsys.readouterr().err
+
+    def test_batch_cite_wraps_results_and_forwards_flag(self, mocker, capsys):
+        ada = _rich_result(_FixtureSchema(name="Ada", age=36), citations=(_CITE_NAME,))
+        mock_stream = _patch_iter_extractions(mocker, events=[(0, ada), (1, ada)])
+
+        assert main(["a.pdf", "b.pdf", *_BASE_ARGS, "--cite"]) == 0
+
+        options = mock_stream.call_args.args[3]
+        assert options.cite is True
+        assert options.rich is True
+        payload = json.loads(capsys.readouterr().out)
+        assert payload == [
+            {
+                "result": {"name": "Ada", "age": 36},
+                "citations": [{"field": "name", "quote": "Ada", "page": 1}],
+            },
+            {
+                "result": {"name": "Ada", "age": 36},
+                "citations": [{"field": "name", "quote": "Ada", "page": 1}],
+            },
+        ]
+
+    def test_jsonl_cite_adds_citations_to_records(self, mocker, capsys):
+        ada = _rich_result(_FixtureSchema(name="Ada", age=36), citations=(_CITE_NAME,))
+        _patch_iter_extractions(mocker, events=[(0, ada)])
+
+        assert main(["a.pdf", *_BASE_ARGS, "--output", "jsonl", "--cite"]) == 0
+
+        lines = [json.loads(line) for line in capsys.readouterr().out.splitlines()]
+        assert lines == [
+            {
+                "index": 0,
+                "input": "a.pdf",
+                "result": {"name": "Ada", "age": 36},
+                "citations": [{"field": "name", "quote": "Ada", "page": 1}],
+            }
+        ]
+
+    def test_batch_cite_with_usage_keeps_usage_envelope(self, mocker, capsys):
+        ada = _rich_result(
+            _FixtureSchema(name="Ada", age=36),
+            input_tokens=10,
+            output_tokens=5,
+            citations=(_CITE_NAME,),
+        )
+        _patch_iter_extractions(mocker, events=[(0, ada)])
+
+        assert main(["a.pdf", "b.pdf", *_BASE_ARGS, "--cite", "--usage"]) == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["results"][0]["citations"] == [{"field": "name", "quote": "Ada", "page": 1}]
+        assert payload["results"][0]["usage"]["total_tokens"] == 15
+
+    def test_swarm_cite_merges_agent_citations(self, mocker, capsys):
+        cited = _rich_result(_FixtureSchema(name="Ada", age=36), citations=(_CITE_NAME,))
+        stub = _SwarmResultStub()
+        stub.agents = (cited, ModelError("boom"))
+        _patch_swarm(mocker, usage_result=stub)
+
+        assert main(["input.txt", *_BASE_ARGS, "--swarm", "2", "--cite"]) == 0
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["result"] == {"name": "Ada", "age": 36}
+        assert payload["citations"] == [{"field": "name", "quote": "Ada", "page": 1}]
+        assert "usage" not in payload
+
+    def test_fanning_agent_with_cite_uses_swarm(self, mocker, tmp_path, capsys):
+        first = _write_agent(tmp_path / "a.py", description="First")
+        second = _write_agent(tmp_path / "b.py", description="Second")
+        parent = tmp_path / "parent.py"
+        parent.write_text(
+            "from openextract import define_agent, load_agent\n"
+            "from tests.test_cli import _FixtureSchema\n"
+            f"agent = define_agent('Parent', output_schema=_FixtureSchema, "
+            f"subagents=[load_agent({first!r}), load_agent({second!r})])\n",
+            encoding="utf-8",
+        )
+        stub = _SwarmResultStub()
+        stub.agents = (_rich_result(_FixtureSchema(name="Ada", age=36), citations=(_CITE_AGE,)),)
+        _, rich = _patch_swarm(mocker, usage_result=stub)
+
+        assert main(["input.txt", "--agent", str(parent), "--cite"]) == 0
+
+        rich.assert_called_once()
+        assert rich.call_args.kwargs["cite"] is True
+        assert json.loads(capsys.readouterr().out)["citations"][0]["bbox"] == [
+            0.1,
+            0.2,
+            0.3,
+            0.05,
+        ]
+
+    def test_single_agent_with_cite_stays_oneshot(self, mocker, tmp_path, capsys):
+        path = _write_agent(tmp_path / "invoices.py")
+        mock_fn = _patch_extract_many_with_results(
+            mocker,
+            return_value=[_rich_result(_FixtureSchema(name="Ada", age=36))],
+        )
+        swarm = mocker.patch("openextract._cli.extract_swarm_with_results")
+
+        assert main(["input.txt", "--agent", path, "--cite"]) == 0
+
+        swarm.assert_not_called()
+        assert mock_fn.call_args.kwargs["cite"] is True
+        capsys.readouterr()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add CLI `--cite` so maintainers and users can request per-field citations from the command line. The Python API already supports `cite=True`; the CLI did not.

## Changes

- Add `--cite` (default off) to `src/openextract/_cli.py`.
- Forward `cite=True` through the same library path used by extract/batch/swarm (parse-then-extract when the PDF extra is available).
- JSON/jsonl success payloads include a `citations` array of `{field, quote, page}` objects, plus `bbox` only when the parser attached one.
- Existing non-cite output shapes are unchanged.
- Injected-agent incompatibility surfaces as the library `ValueError` (exit `1`).
- Tests in `tests/test_cli.py` cover flag wiring and JSON citation payloads (mocks + `TestModel`, no live network).
- CHANGELOG Unreleased (Added). No version bump.

## Testing

- `uv run pytest` — 816 passed, 5 skipped, 100% coverage
- `uv run ruff check .` and `ruff format --check .` — passed
- `uv run ty check` — passed

## Checklist

- [x] Tests pass locally (`uv run pytest`)
- [x] Linting passes (`uv run ruff check .`)
- [x] Documentation updated (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1573ae3a-8678-4644-9d59-f6a8e7cc07de?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1573ae3a-8678-4644-9d59-f6a8e7cc07de&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

